### PR TITLE
SpellFactoryMgr::AddSpellByNameHash not working

### DIFF
--- a/src/arcemu-world/World.cpp
+++ b/src/arcemu-world/World.cpp
@@ -389,9 +389,10 @@ bool World::SetInitialWorldSettings()
 	new WorldLog;
 	new ChatHandler;
 	new SpellProcMgr;
-	new SpellFactoryMgr;
 
 	ApplyNormalFixes();
+
+	new SpellFactoryMgr;
 
 #define MAKE_TASK(sp, ptr) tl.AddTask(new Task(new CallbackP0<sp>(sp::getSingletonPtr(), &sp::ptr)))
 	// Fill the task list with jobs to do.


### PR DESCRIPTION
Hey all, I've just found that SpellFactoryMgr::AddSpellByNameHash is not working correctly and is never registered (thanks Neo_mat for the notice).

There is a logic error when core is starting up, just because SpellFactoryMgr::Setup() is called when creating new SpellFactoryMgr in World.cpp ( and from setup also also AddSpellByNameHash is called if there is any ), before name hashes are initialized for all spells.

This check is in function SpellFactoryMgr::AddSpellByNameHash
<code>
if(sp->NameHash != name_hash)
            continue;
</code>

so in this case, sp->NameHash is empty string, because name hashes are initialized in function called ApplyNormalFixes(), which is obviously called AFTER creating this SpellFactory singleton.

Neo_mat tested my solution and proved me that it's working.
