### PR TITLE
"Captain Garran Vimes" quests in Theramore do not work. Fixed.

### DIFF
--- a/src/scripts/src/GossipScripts/Gossip_Theramore.cpp
+++ b/src/scripts/src/GossipScripts/Gossip_Theramore.cpp
@@ -55,7 +55,7 @@ class CaptainGarranVimes_Gossip : public Arcemu::Gossip::Script
 			Arcemu::Gossip::Menu menu(pObject->GetGUID(), Text, plr->GetSession()->language);
 			sQuestMgr.FillQuestMenu(TO_CREATURE(pObject), plr, menu);
 			if((plr->GetQuestLogForEntry(11123) != NULL) || (plr->GetQuestRewardStatus(11123) == 0)) 
-				menu.AddItem(Arcemu::Gossip::ICON_CHAT, "What have you heard of the Shady Rest Inn?", 1794);
+				menu.AddItem(Arcemu::Gossip::ICON_CHAT, "What have you heard of the Shady Rest Inn?", 0);
 			menu.Send(plr);
 		}
 


### PR DESCRIPTION
To display the correct NPC text instead of the default one a new entry has to be made into the world database into the table 'npc_gossip_textid' .

INSERT INTO `npc_gossip_textid` (`creatureid`, `textid`) VALUES (4944, 1793);
