### PR TITLE
Fix linker errors about libdl happening on openSUSE 11.4

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -167,6 +167,8 @@ if(WIN32)
 	SET(EXTRA_LIBS ${EXTRA_LIBS} ws2_32.lib dbghelp.lib )
 elseif(APPLE)
 	SET( EXTRA_LIBS ${EXTRA_LIBS} "-framework Carbon" )
+else()
+	SET( EXTRA_LIBS ${EXTRA_LIBS} dl )
 endif()
 
 IF( APPLE )


### PR DESCRIPTION
- Some new compilers/distributions no longer link to libdl automatically
- so we have to explicitly force it
