### PR TITLE
Update dep/src/g3dlite/g3dmath.cpp:

### DIFF
--- a/dep/src/g3dlite/g3dmath.cpp
+++ b/dep/src/g3dlite/g3dmath.cpp
@@ -40,7 +40,7 @@ double inf() {
 }
 
 bool isNaN(float x) {
-    static const float n = nan();
+    static const float n = fnan();
     return memcmp(&x, &n, sizeof(float)) == 0;
 }
 


### PR DESCRIPTION
Fix a typo that was fixed by G3D creators ages ago, even before release of 9.0:
http://sourceforge.net/apps/trac/g3d/browser/G3D/G3D9/G3D.lib/source/g3dmath.cpp?rev=24#L44
