### PR TITLE
Spells Damage reduction

### DIFF
--- a/src/arcemu-world/Object.cpp
+++ b/src/arcemu-world/Object.cpp
@@ -1669,7 +1669,7 @@ void Object::SpellNonMeleeDamageLog(Unit* pVictim, uint32 spellID, uint32 damage
 //------------------------------by stats----------------------------------------------------
 	if(IsUnit() && !static_damage)
 	{
-		Unit* caster = TO_UNIT(this);
+		Unit* caster = TO< Unit* >(this);
 
 		caster->RemoveAurasByInterruptFlag(AURA_INTERRUPT_ON_START_ATTACK);
 
@@ -1724,11 +1724,10 @@ void Object::SpellNonMeleeDamageLog(Unit* pVictim, uint32 spellID, uint32 damage
 //==========================================================================================
 
 //------------------------------damage reduction--------------------------------------------
-	float reduce_damage = 0.0f;
-	reduce_damage += static_cast< float >( pVictim->DamageTakenMod[spellInfo->School] );
-	reduce_damage += res * pVictim->DamageTakenPctMod[spellInfo->School];
-	reduce_damage += res * pVictim->ModDamageTakenByMechPCT[spellInfo->MechanicsType];
-	res += reduce_damage;
+	if( this->IsUnit() )
+	{
+		res += TO< Unit* >(this)->CalcSpellDamageReduction(pVictim, spellInfo, res);
+	}
 //------------------------------absorption--------------------------------------------------
 	uint32 ress = (uint32)res;
 	uint32 abs_dmg = pVictim->AbsorbDamage(spellInfo->School, &ress);

--- a/src/arcemu-world/SpellAuras.cpp
+++ b/src/arcemu-world/SpellAuras.cpp
@@ -1821,11 +1821,7 @@ void Aura::EventPeriodicDamage(uint32 amount)
 				res += static_cast< float >( bonus );
 
 				// damage taken is reduced after bonus damage is calculated and added
-				float reduce_damage = 0.0f;
-				reduce_damage += static_cast< float >( m_target->DamageTakenMod[school] );
-				reduce_damage += res * m_target->DamageTakenPctMod[school];
-				reduce_damage += res * m_target->ModDamageTakenByMechPCT[m_spellProto->MechanicsType];
-				res += reduce_damage;
+				res += c->CalcSpellDamageReduction(m_target, m_spellProto, res);
 			}
 
 			if(res < 0.0f)

--- a/src/arcemu-world/Unit.cpp
+++ b/src/arcemu-world/Unit.cpp
@@ -5226,6 +5226,15 @@ int32 Unit::GetSpellDmgBonus(Unit* pVictim, SpellEntry* spellInfo, int32 base_dm
 	return res;
 }
 
+float Unit::CalcSpellDamageReduction(Unit* victim, SpellEntry* spell, float res)
+{
+	float reduced_damage = 0;
+	reduced_damage += static_cast< float >( victim->DamageTakenMod[spell->School] );
+	reduced_damage += res * victim->DamageTakenPctMod[spell->School];
+	reduced_damage += res * victim->ModDamageTakenByMechPCT[spell->MechanicsType];
+	return reduced_damage;
+}
+
 void Unit::InterruptSpell()
 {
 	if(m_currentSpell)

--- a/src/arcemu-world/Unit.h
+++ b/src/arcemu-world/Unit.h
@@ -1236,6 +1236,8 @@ class SERVER_DECL Unit : public Object
 		//caller is the caster
 		int32 GetSpellDmgBonus(Unit* pVictim, SpellEntry* spellInfo, int32 base_dmg, bool isdot);
 
+		float CalcSpellDamageReduction(Unit* victim, SpellEntry* spell, float res);
+
 		uint32 m_addDmgOnce;
 		uint32 m_ObjectSlots[4];
 		uint32 m_triggerSpell;


### PR DESCRIPTION
Damage reduction is now working properly, no flaws have been noticed yet.

Original patch by MesoX: https://gist.github.com/1703083 .

But it was lacking damage reduction for dots, so I had to move out damage reduction calculations from Unit::GetSpellDmgBonus to Object::SpellNonMeleeDamageLog 
and add same into SpellAura::EventPeriodicDamage,
because EventPeriodicDamage is using virtual Object::DealDamage instead of SpellNonMeleeDamageLog as rest of spells do.
