### PR TITLE
Update copyright headers & remove nonexistant project URLs

### DIFF
--- a/src/arcemu-logonserver/AccountCache.cpp
+++ b/src/arcemu-logonserver/AccountCache.cpp
@@ -1,6 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-logonserver/AccountCache.h
+++ b/src/arcemu-logonserver/AccountCache.h
@@ -1,6 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-logonserver/AuthSocket.cpp
+++ b/src/arcemu-logonserver/AuthSocket.cpp
@@ -1,6 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-logonserver/AuthSocket.h
+++ b/src/arcemu-logonserver/AuthSocket.h
@@ -1,6 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-logonserver/AuthStructs.h
+++ b/src/arcemu-logonserver/AuthStructs.h
@@ -1,6 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-logonserver/AutoPatcher.cpp
+++ b/src/arcemu-logonserver/AutoPatcher.cpp
@@ -1,6 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-logonserver/AutoPatcher.h
+++ b/src/arcemu-logonserver/AutoPatcher.h
@@ -1,6 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-logonserver/LogonCommServer.cpp
+++ b/src/arcemu-logonserver/LogonCommServer.cpp
@@ -1,6 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-logonserver/LogonCommServer.h
+++ b/src/arcemu-logonserver/LogonCommServer.h
@@ -1,6 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-logonserver/LogonConsole.cpp
+++ b/src/arcemu-logonserver/LogonConsole.cpp
@@ -1,6 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-logonserver/LogonConsole.h
+++ b/src/arcemu-logonserver/LogonConsole.h
@@ -1,6 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-logonserver/LogonOpcodes.cpp
+++ b/src/arcemu-logonserver/LogonOpcodes.cpp
@@ -1,6 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-logonserver/LogonOpcodes.h
+++ b/src/arcemu-logonserver/LogonOpcodes.h
@@ -1,6 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-logonserver/LogonStdAfx.cpp
+++ b/src/arcemu-logonserver/LogonStdAfx.cpp
@@ -1,6 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-logonserver/LogonStdAfx.h
+++ b/src/arcemu-logonserver/LogonStdAfx.h
@@ -1,6 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-logonserver/Main.cpp
+++ b/src/arcemu-logonserver/Main.cpp
@@ -1,6 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-logonserver/Main.h
+++ b/src/arcemu-logonserver/Main.h
@@ -1,6 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-logonserver/PeriodicFunctionCall_Thread.h
+++ b/src/arcemu-logonserver/PeriodicFunctionCall_Thread.h
@@ -1,6 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-shared/Auth/BigNumber.cpp
+++ b/src/arcemu-shared/Auth/BigNumber.cpp
@@ -1,6 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-shared/Auth/BigNumber.h
+++ b/src/arcemu-shared/Auth/BigNumber.h
@@ -1,6 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-shared/Auth/MD5.cpp
+++ b/src/arcemu-shared/Auth/MD5.cpp
@@ -1,6 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-shared/Auth/MD5.h
+++ b/src/arcemu-shared/Auth/MD5.h
@@ -1,6 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-shared/Auth/Sha1.cpp
+++ b/src/arcemu-shared/Auth/Sha1.cpp
@@ -1,6 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-shared/Auth/Sha1.h
+++ b/src/arcemu-shared/Auth/Sha1.h
@@ -1,6 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-shared/Auth/WowCrypt.cpp
+++ b/src/arcemu-shared/Auth/WowCrypt.cpp
@@ -1,6 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-shared/Auth/WowCrypt.h
+++ b/src/arcemu-shared/Auth/WowCrypt.h
@@ -1,6 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-shared/AuthCodes.h
+++ b/src/arcemu-shared/AuthCodes.h
@@ -1,6 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-shared/ByteBuffer.h
+++ b/src/arcemu-shared/ByteBuffer.h
@@ -1,6 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-shared/CRefcounter.h
+++ b/src/arcemu-shared/CRefcounter.h
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-shared/CThreads.cpp
+++ b/src/arcemu-shared/CThreads.cpp
@@ -1,6 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-shared/CThreads.h
+++ b/src/arcemu-shared/CThreads.h
@@ -1,6 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-shared/CallBack.h
+++ b/src/arcemu-shared/CallBack.h
@@ -1,6 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-shared/Common.h
+++ b/src/arcemu-shared/Common.h
@@ -1,6 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-shared/Config/Config.cpp
+++ b/src/arcemu-shared/Config/Config.cpp
@@ -1,6 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-shared/Config/Config.h
+++ b/src/arcemu-shared/Config/Config.h
@@ -1,6 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-shared/Config/ConfigEnv.h
+++ b/src/arcemu-shared/Config/ConfigEnv.h
@@ -1,6 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-shared/CrashHandler.cpp
+++ b/src/arcemu-shared/CrashHandler.cpp
@@ -1,6 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-shared/CrashHandler.h
+++ b/src/arcemu-shared/CrashHandler.h
@@ -1,6 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-shared/Database/CreateInterface.cpp
+++ b/src/arcemu-shared/Database/CreateInterface.cpp
@@ -1,6 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-shared/Database/DataStore.h
+++ b/src/arcemu-shared/Database/DataStore.h
@@ -1,6 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-shared/Database/Database.cpp
+++ b/src/arcemu-shared/Database/Database.cpp
@@ -1,6 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-shared/Database/Database.h
+++ b/src/arcemu-shared/Database/Database.h
@@ -1,6 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-shared/Database/DatabaseEnv.h
+++ b/src/arcemu-shared/Database/DatabaseEnv.h
@@ -1,6 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-shared/Database/Field.h
+++ b/src/arcemu-shared/Database/Field.h
@@ -1,6 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-shared/Database/MySQLDatabase.cpp
+++ b/src/arcemu-shared/Database/MySQLDatabase.cpp
@@ -1,7 +1,7 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
- * Copyright (C) 2005-2007 arcemu Team <http://www.arcemuemu.com/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2005-2007 Ascent Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-shared/Database/MySQLDatabase.h
+++ b/src/arcemu-shared/Database/MySQLDatabase.h
@@ -1,6 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-shared/DynLib.cpp
+++ b/src/arcemu-shared/DynLib.cpp
@@ -1,6 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-shared/DynLib.hpp
+++ b/src/arcemu-shared/DynLib.hpp
@@ -1,6 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-shared/Errors.h
+++ b/src/arcemu-shared/Errors.h
@@ -1,6 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-shared/FastQueue.h
+++ b/src/arcemu-shared/FastQueue.h
@@ -1,6 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-shared/FindFiles.cpp
+++ b/src/arcemu-shared/FindFiles.cpp
@@ -1,6 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-shared/FindFiles.hpp
+++ b/src/arcemu-shared/FindFiles.hpp
@@ -1,6 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-shared/FindFilesResult.hpp
+++ b/src/arcemu-shared/FindFilesResult.hpp
@@ -1,6 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-shared/LocationVector.h
+++ b/src/arcemu-shared/LocationVector.h
@@ -1,6 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-shared/Log.cpp
+++ b/src/arcemu-shared/Log.cpp
@@ -1,6 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-shared/Log.h
+++ b/src/arcemu-shared/Log.h
@@ -1,6 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-shared/MersenneTwister.cpp
+++ b/src/arcemu-shared/MersenneTwister.cpp
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-shared/MersenneTwister.h
+++ b/src/arcemu-shared/MersenneTwister.h
@@ -1,6 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-shared/PerformanceCounter.cpp
+++ b/src/arcemu-shared/PerformanceCounter.cpp
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-shared/PerformanceCounter.hpp
+++ b/src/arcemu-shared/PerformanceCounter.hpp
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-shared/PreallocatedQueue.h
+++ b/src/arcemu-shared/PreallocatedQueue.h
@@ -1,6 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-shared/Singleton.h
+++ b/src/arcemu-shared/Singleton.h
@@ -1,6 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-shared/StackBuffer.h
+++ b/src/arcemu-shared/StackBuffer.h
@@ -1,6 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-shared/Storage.h
+++ b/src/arcemu-shared/Storage.h
@@ -1,6 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-shared/SysInfo.cpp
+++ b/src/arcemu-shared/SysInfo.cpp
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-shared/SysInfo.hpp
+++ b/src/arcemu-shared/SysInfo.hpp
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-shared/TLSObject.h
+++ b/src/arcemu-shared/TLSObject.h
@@ -1,6 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-shared/Threading/AtomicBoolean.cpp
+++ b/src/arcemu-shared/Threading/AtomicBoolean.cpp
@@ -1,6 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-shared/Threading/AtomicBoolean.h
+++ b/src/arcemu-shared/Threading/AtomicBoolean.h
@@ -1,6 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-shared/Threading/AtomicCounter.cpp
+++ b/src/arcemu-shared/Threading/AtomicCounter.cpp
@@ -1,6 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-shared/Threading/AtomicCounter.h
+++ b/src/arcemu-shared/Threading/AtomicCounter.h
@@ -1,6 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-shared/Threading/AtomicFloat.cpp
+++ b/src/arcemu-shared/Threading/AtomicFloat.cpp
@@ -1,6 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-shared/Threading/AtomicFloat.h
+++ b/src/arcemu-shared/Threading/AtomicFloat.h
@@ -1,6 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-shared/Threading/AtomicULong.cpp
+++ b/src/arcemu-shared/Threading/AtomicULong.cpp
@@ -1,6 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-shared/Threading/AtomicULong.h
+++ b/src/arcemu-shared/Threading/AtomicULong.h
@@ -1,6 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-shared/Threading/ConditionVariable.cpp
+++ b/src/arcemu-shared/Threading/ConditionVariable.cpp
@@ -1,6 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-shared/Threading/ConditionVariable.h
+++ b/src/arcemu-shared/Threading/ConditionVariable.h
@@ -1,6 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-shared/Threading/Guard.h
+++ b/src/arcemu-shared/Threading/Guard.h
@@ -1,6 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-shared/Threading/LockedQueue.h
+++ b/src/arcemu-shared/Threading/LockedQueue.h
@@ -1,6 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-shared/Threading/Mutex.cpp
+++ b/src/arcemu-shared/Threading/Mutex.cpp
@@ -1,6 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-shared/Threading/Mutex.h
+++ b/src/arcemu-shared/Threading/Mutex.h
@@ -1,6 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-shared/Threading/Queue.h
+++ b/src/arcemu-shared/Threading/Queue.h
@@ -1,6 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-shared/Threading/RWLock.h
+++ b/src/arcemu-shared/Threading/RWLock.h
@@ -1,6 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-shared/Threading/ThreadStarter.h
+++ b/src/arcemu-shared/Threading/ThreadStarter.h
@@ -1,6 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-shared/Threading/Threading.h
+++ b/src/arcemu-shared/Threading/Threading.h
@@ -1,6 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-shared/Tokenizer.h
+++ b/src/arcemu-shared/Tokenizer.h
@@ -1,6 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-shared/Util.cpp
+++ b/src/arcemu-shared/Util.cpp
@@ -1,6 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-shared/Util.h
+++ b/src/arcemu-shared/Util.h
@@ -1,6 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-shared/WoWGuid.h
+++ b/src/arcemu-shared/WoWGuid.h
@@ -1,6 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-shared/WorldPacket.h
+++ b/src/arcemu-shared/WorldPacket.h
@@ -1,6 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2008-2009 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-shared/arcemuConfig.h
+++ b/src/arcemu-shared/arcemuConfig.h
@@ -1,6 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-shared/arcemu_getopt.cpp
+++ b/src/arcemu-shared/arcemu_getopt.cpp
@@ -1,6 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-shared/arcemu_getopt.h
+++ b/src/arcemu-shared/arcemu_getopt.h
@@ -1,6 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/AIEvents.cpp
+++ b/src/arcemu-world/AIEvents.cpp
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/AIEvents.h
+++ b/src/arcemu-world/AIEvents.h
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/AIInterface.cpp
+++ b/src/arcemu-world/AIInterface.cpp
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/AIInterface.h
+++ b/src/arcemu-world/AIInterface.h
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/AchievementMgr.cpp
+++ b/src/arcemu-world/AchievementMgr.cpp
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/AddonMgr.cpp
+++ b/src/arcemu-world/AddonMgr.cpp
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/AddonMgr.h
+++ b/src/arcemu-world/AddonMgr.h
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/AlteracValley.cpp
+++ b/src/arcemu-world/AlteracValley.cpp
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/AlteracValley.h
+++ b/src/arcemu-world/AlteracValley.h
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/ArathiBasin.cpp
+++ b/src/arcemu-world/ArathiBasin.cpp
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/ArathiBasin.h
+++ b/src/arcemu-world/ArathiBasin.h
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/AreaTrigger.cpp
+++ b/src/arcemu-world/AreaTrigger.cpp
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/AreaTrigger.h
+++ b/src/arcemu-world/AreaTrigger.h
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/ArenaTeam.cpp
+++ b/src/arcemu-world/ArenaTeam.cpp
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/ArenaTeam.h
+++ b/src/arcemu-world/ArenaTeam.h
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/Arenas.cpp
+++ b/src/arcemu-world/Arenas.cpp
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/Arenas.h
+++ b/src/arcemu-world/Arenas.h
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/AuctionHouse.cpp
+++ b/src/arcemu-world/AuctionHouse.cpp
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/AuctionHouse.h
+++ b/src/arcemu-world/AuctionHouse.h
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/AuctionMgr.cpp
+++ b/src/arcemu-world/AuctionMgr.cpp
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/AuctionMgr.h
+++ b/src/arcemu-world/AuctionMgr.h
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/BaseConsole.h
+++ b/src/arcemu-world/BaseConsole.h
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/BattlegroundCommands.cpp
+++ b/src/arcemu-world/BattlegroundCommands.cpp
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/BattlegroundHandler.cpp
+++ b/src/arcemu-world/BattlegroundHandler.cpp
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/BattlegroundMgr.cpp
+++ b/src/arcemu-world/BattlegroundMgr.cpp
@@ -1,7 +1,7 @@
 /*
 * ArcEmu MMORPG Server
-* Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
-* Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+* Copyright (C) 2008-2012 ArcEmu 
+* Copyright (C) 2008-2012 ArcEmu 
 *
 * This program is free software: you can redistribute it and/or modify
 * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/BattlegroundMgr.h
+++ b/src/arcemu-world/BattlegroundMgr.h
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/CConsole.cpp
+++ b/src/arcemu-world/CConsole.cpp
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/CConsole.h
+++ b/src/arcemu-world/CConsole.h
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/CellHandler.h
+++ b/src/arcemu-world/CellHandler.h
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/Channel.cpp
+++ b/src/arcemu-world/Channel.cpp
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/Channel.h
+++ b/src/arcemu-world/Channel.h
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/ChannelHandler.cpp
+++ b/src/arcemu-world/ChannelHandler.cpp
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/ChannelMgr.h
+++ b/src/arcemu-world/ChannelMgr.h
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/CharacterHandler.cpp
+++ b/src/arcemu-world/CharacterHandler.cpp
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/Chat.cpp
+++ b/src/arcemu-world/Chat.cpp
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/Chat.h
+++ b/src/arcemu-world/Chat.h
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/ChatHandler.cpp
+++ b/src/arcemu-world/ChatHandler.cpp
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/CollideInterface.cpp
+++ b/src/arcemu-world/CollideInterface.cpp
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/CollideInterface.h
+++ b/src/arcemu-world/CollideInterface.h
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/CombatHandler.cpp
+++ b/src/arcemu-world/CombatHandler.cpp
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/CommonScheduleThread.cpp
+++ b/src/arcemu-world/CommonScheduleThread.cpp
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  * cebernic@gmail.com
  *
  * This program is free software: you can redistribute it and/or modify

--- a/src/arcemu-world/CommonScheduleThread.h
+++ b/src/arcemu-world/CommonScheduleThread.h
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  * cebernic@gmail.com
  *
  * This program is free software: you can redistribute it and/or modify

--- a/src/arcemu-world/ConsoleCommands.cpp
+++ b/src/arcemu-world/ConsoleCommands.cpp
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/ConsoleCommands.h
+++ b/src/arcemu-world/ConsoleCommands.h
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/ConsoleListener.cpp
+++ b/src/arcemu-world/ConsoleListener.cpp
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/Container.cpp
+++ b/src/arcemu-world/Container.cpp
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/Container.h
+++ b/src/arcemu-world/Container.h
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/Corpse.cpp
+++ b/src/arcemu-world/Corpse.cpp
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/Corpse.h
+++ b/src/arcemu-world/Corpse.h
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/Creature.cpp
+++ b/src/arcemu-world/Creature.cpp
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/Creature.h
+++ b/src/arcemu-world/Creature.h
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/DBC/DBCStores.cpp
+++ b/src/arcemu-world/DBC/DBCStores.cpp
@@ -1,6 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/DBC/DBCStores.h
+++ b/src/arcemu-world/DBC/DBCStores.h
@@ -1,6 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/DatabaseCleaner.cpp
+++ b/src/arcemu-world/DatabaseCleaner.cpp
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/DatabaseCleaner.h
+++ b/src/arcemu-world/DatabaseCleaner.h
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/DayWatcherThread.cpp
+++ b/src/arcemu-world/DayWatcherThread.cpp
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/DayWatcherThread.h
+++ b/src/arcemu-world/DayWatcherThread.h
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/DeathKnight.cpp
+++ b/src/arcemu-world/DeathKnight.cpp
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/DeathKnight.h
+++ b/src/arcemu-world/DeathKnight.h
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/Definitions.h
+++ b/src/arcemu-world/Definitions.h
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/Druid.cpp
+++ b/src/arcemu-world/Druid.cpp
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/Druid.h
+++ b/src/arcemu-world/Druid.h
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/DuelHandler.cpp
+++ b/src/arcemu-world/DuelHandler.cpp
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/DynamicObject.cpp
+++ b/src/arcemu-world/DynamicObject.cpp
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/DynamicObject.h
+++ b/src/arcemu-world/DynamicObject.h
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/Entities/Summons/CompanionSummon.cpp
+++ b/src/arcemu-world/Entities/Summons/CompanionSummon.cpp
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/Entities/Summons/CompanionSummon.h
+++ b/src/arcemu-world/Entities/Summons/CompanionSummon.h
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/Entities/Summons/GuardianSummon.cpp
+++ b/src/arcemu-world/Entities/Summons/GuardianSummon.cpp
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/Entities/Summons/GuardianSummon.h
+++ b/src/arcemu-world/Entities/Summons/GuardianSummon.h
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/Entities/Summons/PossessedSummon.cpp
+++ b/src/arcemu-world/Entities/Summons/PossessedSummon.cpp
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/Entities/Summons/PossessedSummon.h
+++ b/src/arcemu-world/Entities/Summons/PossessedSummon.h
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/Entities/Summons/Summon.cpp
+++ b/src/arcemu-world/Entities/Summons/Summon.cpp
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/Entities/Summons/Summon.h
+++ b/src/arcemu-world/Entities/Summons/Summon.h
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/Entities/Summons/TotemSummon.cpp
+++ b/src/arcemu-world/Entities/Summons/TotemSummon.cpp
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/Entities/Summons/TotemSummon.h
+++ b/src/arcemu-world/Entities/Summons/TotemSummon.h
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/Entities/Summons/WildSummon.cpp
+++ b/src/arcemu-world/Entities/Summons/WildSummon.cpp
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/Entities/Summons/WildSummon.h
+++ b/src/arcemu-world/Entities/Summons/WildSummon.h
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/EquipmentSetMgr.cpp
+++ b/src/arcemu-world/EquipmentSetMgr.cpp
@@ -1,6 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/EquipmentSetMgr.h
+++ b/src/arcemu-world/EquipmentSetMgr.h
@@ -1,6 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/EventMgr.cpp
+++ b/src/arcemu-world/EventMgr.cpp
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/EventMgr.h
+++ b/src/arcemu-world/EventMgr.h
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/EventableObject.cpp
+++ b/src/arcemu-world/EventableObject.cpp
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/EventableObject.h
+++ b/src/arcemu-world/EventableObject.h
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/Events.h
+++ b/src/arcemu-world/Events.h
@@ -1,6 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/EyeOfTheStorm.cpp
+++ b/src/arcemu-world/EyeOfTheStorm.cpp
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/EyeOfTheStorm.h
+++ b/src/arcemu-world/EyeOfTheStorm.h
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/GMTicket.cpp
+++ b/src/arcemu-world/GMTicket.cpp
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/GMTicketCommands.cpp
+++ b/src/arcemu-world/GMTicketCommands.cpp
@@ -1,7 +1,7 @@
 /*
 * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
-* Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+* Copyright (C) 2008-2012 ArcEmu 
 *
 * This program is free software: you can redistribute it and/or modify
 * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/GameObject.cpp
+++ b/src/arcemu-world/GameObject.cpp
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/GameObject.h
+++ b/src/arcemu-world/GameObject.h
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/Group.cpp
+++ b/src/arcemu-world/Group.cpp
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/Group.h
+++ b/src/arcemu-world/Group.h
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/GroupHandler.cpp
+++ b/src/arcemu-world/GroupHandler.cpp
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/Guild.cpp
+++ b/src/arcemu-world/Guild.cpp
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/Guild.h
+++ b/src/arcemu-world/Guild.h
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/GuildHandler.cpp
+++ b/src/arcemu-world/GuildHandler.cpp
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/HackFixes.cpp
+++ b/src/arcemu-world/HackFixes.cpp
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/HonorHandler.cpp
+++ b/src/arcemu-world/HonorHandler.cpp
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/HonorHandler.h
+++ b/src/arcemu-world/HonorHandler.h
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/Hunter.cpp
+++ b/src/arcemu-world/Hunter.cpp
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/Hunter.h
+++ b/src/arcemu-world/Hunter.h
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/IEventListener.h
+++ b/src/arcemu-world/IEventListener.h
@@ -1,6 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/InstanceCommands.cpp
+++ b/src/arcemu-world/InstanceCommands.cpp
@@ -1,7 +1,7 @@
 /*
 * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
-* Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+* Copyright (C) 2008-2012 ArcEmu 
 *
 * This program is free software: you can redistribute it and/or modify
 * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/IsleOfConquest.cpp
+++ b/src/arcemu-world/IsleOfConquest.cpp
@@ -1,6 +1,6 @@
 /*
- * Arcemu
- * Copyright (C) 2008 - 2011 Arcemu <http://www.arcemu.org/>
+ * ArcEmu MMORPG Server
+ * Copyright (C) 2008 - 2012 Arcemu 
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/IsleOfConquest.h
+++ b/src/arcemu-world/IsleOfConquest.h
@@ -1,6 +1,6 @@
 /*
- * Arcemu
- * Copyright (C) 2008 - 2011 Arcemu <http://www.arcemu.org/>
+ * ArcEmu MMORPG Server
+ * Copyright (C) 2008 - 2012 Arcemu 
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/Item.cpp
+++ b/src/arcemu-world/Item.cpp
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/Item.h
+++ b/src/arcemu-world/Item.h
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/ItemHandler.cpp
+++ b/src/arcemu-world/ItemHandler.cpp
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/ItemInterface.cpp
+++ b/src/arcemu-world/ItemInterface.cpp
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/ItemInterface.h
+++ b/src/arcemu-world/ItemInterface.h
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/ItemPrototype.h
+++ b/src/arcemu-world/ItemPrototype.h
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/Level0.cpp
+++ b/src/arcemu-world/Level0.cpp
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/Level1.cpp
+++ b/src/arcemu-world/Level1.cpp
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/Level2.cpp
+++ b/src/arcemu-world/Level2.cpp
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/Level3.cpp
+++ b/src/arcemu-world/Level3.cpp
@@ -1,7 +1,7 @@
 /*
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  * ArcEmu MMORPG Server
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/LfgHandler.cpp
+++ b/src/arcemu-world/LfgHandler.cpp
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/LfgMgr.cpp
+++ b/src/arcemu-world/LfgMgr.cpp
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/LfgMgr.h
+++ b/src/arcemu-world/LfgMgr.h
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/LocalizationMgr.cpp
+++ b/src/arcemu-world/LocalizationMgr.cpp
@@ -1,5 +1,5 @@
 /*
- * arcemu MMORPG Server
+ * ArcEmu MMORPG Server
  * String Localization Manager
  * Copyright (C) 2007 Burlex <burlex@gmail.com>
  *

--- a/src/arcemu-world/LocalizationMgr.h
+++ b/src/arcemu-world/LocalizationMgr.h
@@ -1,5 +1,5 @@
 /*
- * arcemu MMORPG Server
+ * ArcEmu MMORPG Server
  * String Localization Manager
  * Copyright (C) 2007 Burlex <burlex@gmail.com>
  *

--- a/src/arcemu-world/LogonCommClient.cpp
+++ b/src/arcemu-world/LogonCommClient.cpp
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/LogonCommClient.h
+++ b/src/arcemu-world/LogonCommClient.h
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/LogonCommHandler.cpp
+++ b/src/arcemu-world/LogonCommHandler.cpp
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/LogonCommHandler.h
+++ b/src/arcemu-world/LogonCommHandler.h
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/LootMgr.cpp
+++ b/src/arcemu-world/LootMgr.cpp
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/LootMgr.h
+++ b/src/arcemu-world/LootMgr.h
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/Mage.cpp
+++ b/src/arcemu-world/Mage.cpp
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/Mage.h
+++ b/src/arcemu-world/Mage.h
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/MailSystem.cpp
+++ b/src/arcemu-world/MailSystem.cpp
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/MailSystem.h
+++ b/src/arcemu-world/MailSystem.h
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/Main.cpp
+++ b/src/arcemu-world/Main.cpp
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/MainServerDefines.h
+++ b/src/arcemu-world/MainServerDefines.h
@@ -1,6 +1,6 @@
 /*
- * OpenAscent MMORPG Server
- * Copyright (C) 2008 <http://www.openascent.com/>
+ * ArcEmu MMORPG Server
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/Map.cpp
+++ b/src/arcemu-world/Map.cpp
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/Map.h
+++ b/src/arcemu-world/Map.h
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/MapCell.cpp
+++ b/src/arcemu-world/MapCell.cpp
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/MapCell.h
+++ b/src/arcemu-world/MapCell.h
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/MapMgr.cpp
+++ b/src/arcemu-world/MapMgr.cpp
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/MapMgr.h
+++ b/src/arcemu-world/MapMgr.h
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/MapMgrEventHandlers.cpp
+++ b/src/arcemu-world/MapMgrEventHandlers.cpp
@@ -1,6 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/MapScriptInterface.cpp
+++ b/src/arcemu-world/MapScriptInterface.cpp
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/MapScriptInterface.h
+++ b/src/arcemu-world/MapScriptInterface.h
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/Master.cpp
+++ b/src/arcemu-world/Master.cpp
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/Master.h
+++ b/src/arcemu-world/Master.h
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/MiscHandler.cpp
+++ b/src/arcemu-world/MiscHandler.cpp
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/MovementHandler.cpp
+++ b/src/arcemu-world/MovementHandler.cpp
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/NPCHandler.cpp
+++ b/src/arcemu-world/NPCHandler.cpp
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/NPCHandler.h
+++ b/src/arcemu-world/NPCHandler.h
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/NameTables.h
+++ b/src/arcemu-world/NameTables.h
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/Object.cpp
+++ b/src/arcemu-world/Object.cpp
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/Object.h
+++ b/src/arcemu-world/Object.h
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/ObjectMgr.cpp
+++ b/src/arcemu-world/ObjectMgr.cpp
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/ObjectMgr.h
+++ b/src/arcemu-world/ObjectMgr.h
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/ObjectStorage.cpp
+++ b/src/arcemu-world/ObjectStorage.cpp
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/ObjectStorage.h
+++ b/src/arcemu-world/ObjectStorage.h
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/Opcodes.cpp
+++ b/src/arcemu-world/Opcodes.cpp
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/Opcodes.h
+++ b/src/arcemu-world/Opcodes.h
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/Paladin.cpp
+++ b/src/arcemu-world/Paladin.cpp
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/Paladin.h
+++ b/src/arcemu-world/Paladin.h
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/Pet.cpp
+++ b/src/arcemu-world/Pet.cpp
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/Pet.h
+++ b/src/arcemu-world/Pet.h
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/PetHandler.cpp
+++ b/src/arcemu-world/PetHandler.cpp
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/Player.cpp
+++ b/src/arcemu-world/Player.cpp
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/Player.h
+++ b/src/arcemu-world/Player.h
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/PlayerPacketWrapper.cpp
+++ b/src/arcemu-world/PlayerPacketWrapper.cpp
@@ -1,6 +1,6 @@
 /*
-* arcemu MMORPG Server
-* Copyright (C) 2005-2007 arcemu Team <http://www.arcemuemu.com/>
+* ArcEmu MMORPG Server
+* Copyright (C) 2005-2007 Ascent Team
 *
 * This program is free software: you can redistribute it and/or modify
 * it under the terms of the GNU General Public License as published by

--- a/src/arcemu-world/Priest.cpp
+++ b/src/arcemu-world/Priest.cpp
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/Priest.h
+++ b/src/arcemu-world/Priest.h
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/QueryHandler.cpp
+++ b/src/arcemu-world/QueryHandler.cpp
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/Quest.cpp
+++ b/src/arcemu-world/Quest.cpp
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/Quest.h
+++ b/src/arcemu-world/Quest.h
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/QuestHandler.cpp
+++ b/src/arcemu-world/QuestHandler.cpp
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/QuestMgr.cpp
+++ b/src/arcemu-world/QuestMgr.cpp
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/QuestMgr.h
+++ b/src/arcemu-world/QuestMgr.h
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/RaidHandler.cpp
+++ b/src/arcemu-world/RaidHandler.cpp
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/RecallCommands.cpp
+++ b/src/arcemu-world/RecallCommands.cpp
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/ReputationHandler.cpp
+++ b/src/arcemu-world/ReputationHandler.cpp
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/Rogue.cpp
+++ b/src/arcemu-world/Rogue.cpp
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/Rogue.h
+++ b/src/arcemu-world/Rogue.h
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/ScriptMgr.cpp
+++ b/src/arcemu-world/ScriptMgr.cpp
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/ScriptMgr.h
+++ b/src/arcemu-world/ScriptMgr.h
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/ScriptSetup.h
+++ b/src/arcemu-world/ScriptSetup.h
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/Shaman.cpp
+++ b/src/arcemu-world/Shaman.cpp
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/Shaman.h
+++ b/src/arcemu-world/Shaman.h
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/SocialHandler.cpp
+++ b/src/arcemu-world/SocialHandler.cpp
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/Spell.cpp
+++ b/src/arcemu-world/Spell.cpp
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/Spell.h
+++ b/src/arcemu-world/Spell.h
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/SpellAuras.cpp
+++ b/src/arcemu-world/SpellAuras.cpp
@@ -1,7 +1,7 @@
 /*
 * ArcEmu MMORPG Server
-* Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
-* Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+* Copyright (C) 2008-2012 ArcEmu 
+* Copyright (C) 2008-2012 ArcEmu 
 *
 * This program is free software: you can redistribute it and/or modify
 * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/SpellAuras.h
+++ b/src/arcemu-world/SpellAuras.h
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/SpellEffects.cpp
+++ b/src/arcemu-world/SpellEffects.cpp
@@ -1,7 +1,7 @@
 /*
 * ArcEmu MMORPG Server
-* Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
-* Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+* Copyright (C) 2008-2012 ArcEmu 
+* Copyright (C) 2008-2012 ArcEmu 
 *
 * This program is free software: you can redistribute it and/or modify
 * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/SpellFailure.h
+++ b/src/arcemu-world/SpellFailure.h
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/SpellHandler.cpp
+++ b/src/arcemu-world/SpellHandler.cpp
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/SpellMgr.cpp
+++ b/src/arcemu-world/SpellMgr.cpp
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/SpellMgr.h
+++ b/src/arcemu-world/SpellMgr.h
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/SpellNameHashes.h
+++ b/src/arcemu-world/SpellNameHashes.h
@@ -1,6 +1,6 @@
 /*
- * ArcEMU MMORPG Server
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * ArcEmu MMORPG Server
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/SpellProc.cpp
+++ b/src/arcemu-world/SpellProc.cpp
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/SpellProc.h
+++ b/src/arcemu-world/SpellProc.h
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/SpellProc_DeathKnight.cpp
+++ b/src/arcemu-world/SpellProc_DeathKnight.cpp
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/SpellProc_Druid.cpp
+++ b/src/arcemu-world/SpellProc_Druid.cpp
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/SpellProc_Hunter.cpp
+++ b/src/arcemu-world/SpellProc_Hunter.cpp
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/SpellProc_Items.cpp
+++ b/src/arcemu-world/SpellProc_Items.cpp
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/SpellProc_Mage.cpp
+++ b/src/arcemu-world/SpellProc_Mage.cpp
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/SpellProc_Paladin.cpp
+++ b/src/arcemu-world/SpellProc_Paladin.cpp
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/SpellProc_Priest.cpp
+++ b/src/arcemu-world/SpellProc_Priest.cpp
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/SpellProc_Rogue.cpp
+++ b/src/arcemu-world/SpellProc_Rogue.cpp
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/SpellProc_Shaman.cpp
+++ b/src/arcemu-world/SpellProc_Shaman.cpp
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/SpellProc_Warlock.cpp
+++ b/src/arcemu-world/SpellProc_Warlock.cpp
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/SpellProc_Warrior.cpp
+++ b/src/arcemu-world/SpellProc_Warrior.cpp
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/SpellTarget.cpp
+++ b/src/arcemu-world/SpellTarget.cpp
@@ -1,6 +1,6 @@
 /*
-* arcemu MMORPG Server
-* Copyright (C) 2005-2007 arcemu Team <http://www.arcemuemu.com/>
+* ArcEmu MMORPG Server
+* Copyright (C) 2005-2007 Ascent Team
 *
 * This program is free software: you can redistribute it and/or modify
 * it under the terms of the GNU General Public License as published by

--- a/src/arcemu-world/SpellTarget.h
+++ b/src/arcemu-world/SpellTarget.h
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/Spell_DeathKnight.cpp
+++ b/src/arcemu-world/Spell_DeathKnight.cpp
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/Spell_Druid.cpp
+++ b/src/arcemu-world/Spell_Druid.cpp
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/Spell_Hunter.cpp
+++ b/src/arcemu-world/Spell_Hunter.cpp
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/Spell_Mage.cpp
+++ b/src/arcemu-world/Spell_Mage.cpp
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/Spell_Paladin.cpp
+++ b/src/arcemu-world/Spell_Paladin.cpp
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/Spell_Priest.cpp
+++ b/src/arcemu-world/Spell_Priest.cpp
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/Spell_Rogue.cpp
+++ b/src/arcemu-world/Spell_Rogue.cpp
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/Spell_Shaman.cpp
+++ b/src/arcemu-world/Spell_Shaman.cpp
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/Spell_Warlock.cpp
+++ b/src/arcemu-world/Spell_Warlock.cpp
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/Spell_Warrior.cpp
+++ b/src/arcemu-world/Spell_Warrior.cpp
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/Stats.cpp
+++ b/src/arcemu-world/Stats.cpp
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/Stats.h
+++ b/src/arcemu-world/Stats.h
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/StdAfx.cpp
+++ b/src/arcemu-world/StdAfx.cpp
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/StdAfx.h
+++ b/src/arcemu-world/StdAfx.h
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/StrandOfTheAncient.cpp
+++ b/src/arcemu-world/StrandOfTheAncient.cpp
@@ -1,6 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/StrandOfTheAncient.h
+++ b/src/arcemu-world/StrandOfTheAncient.h
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/SummonHandler.cpp
+++ b/src/arcemu-world/SummonHandler.cpp
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/SummonHandler.h
+++ b/src/arcemu-world/SummonHandler.h
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/TaxiHandler.cpp
+++ b/src/arcemu-world/TaxiHandler.cpp
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/TaxiMgr.cpp
+++ b/src/arcemu-world/TaxiMgr.cpp
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/TaxiMgr.h
+++ b/src/arcemu-world/TaxiMgr.h
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/TerrainMgr.cpp
+++ b/src/arcemu-world/TerrainMgr.cpp
@@ -1,6 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/TerrainMgr.h
+++ b/src/arcemu-world/TerrainMgr.h
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/TradeHandler.cpp
+++ b/src/arcemu-world/TradeHandler.cpp
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/TransporterHandler.cpp
+++ b/src/arcemu-world/TransporterHandler.cpp
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/TransporterHandler.h
+++ b/src/arcemu-world/TransporterHandler.h
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/Unit.cpp
+++ b/src/arcemu-world/Unit.cpp
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/Unit.h
+++ b/src/arcemu-world/Unit.h
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/UpdateFields.h
+++ b/src/arcemu-world/UpdateFields.h
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/UpdateMask.h
+++ b/src/arcemu-world/UpdateMask.h
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/Vehicle.cpp
+++ b/src/arcemu-world/Vehicle.cpp
@@ -1,6 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/Vehicle.h
+++ b/src/arcemu-world/Vehicle.h
@@ -1,6 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/VehicleHandler.cpp
+++ b/src/arcemu-world/VehicleHandler.cpp
@@ -1,6 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/VoiceChatHandler.cpp
+++ b/src/arcemu-world/VoiceChatHandler.cpp
@@ -1,5 +1,5 @@
 /*
- * arcemu MMORPG Server
+ * ArcEmu MMORPG Server
  * Voice Chat Engine
  * Copyright (C) 2005-2007 Burlex <burlex@gmail.com>
  *

--- a/src/arcemu-world/WUtil.cpp
+++ b/src/arcemu-world/WUtil.cpp
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/WUtil.h
+++ b/src/arcemu-world/WUtil.h
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/Warlock.cpp
+++ b/src/arcemu-world/Warlock.cpp
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/Warlock.h
+++ b/src/arcemu-world/Warlock.h
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/Warrior.cpp
+++ b/src/arcemu-world/Warrior.cpp
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/Warrior.h
+++ b/src/arcemu-world/Warrior.h
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/WarsongGulch.cpp
+++ b/src/arcemu-world/WarsongGulch.cpp
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/WarsongGulch.h
+++ b/src/arcemu-world/WarsongGulch.h
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/WayPoints.cpp
+++ b/src/arcemu-world/WayPoints.cpp
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/WeatherMgr.cpp
+++ b/src/arcemu-world/WeatherMgr.cpp
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/WeatherMgr.h
+++ b/src/arcemu-world/WeatherMgr.h
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/WordFilter.cpp
+++ b/src/arcemu-world/WordFilter.cpp
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/WordFilter.h
+++ b/src/arcemu-world/WordFilter.h
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/World.cpp
+++ b/src/arcemu-world/World.cpp
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/World.h
+++ b/src/arcemu-world/World.h
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/WorldCreator.cpp
+++ b/src/arcemu-world/WorldCreator.cpp
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/WorldCreator.h
+++ b/src/arcemu-world/WorldCreator.h
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/WorldRunnable.cpp
+++ b/src/arcemu-world/WorldRunnable.cpp
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/WorldRunnable.h
+++ b/src/arcemu-world/WorldRunnable.h
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/WorldSession.cpp
+++ b/src/arcemu-world/WorldSession.cpp
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/WorldSession.h
+++ b/src/arcemu-world/WorldSession.h
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/WorldSocket.cpp
+++ b/src/arcemu-world/WorldSocket.cpp
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/WorldSocket.h
+++ b/src/arcemu-world/WorldSocket.h
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/WorldStatesHandler.cpp
+++ b/src/arcemu-world/WorldStatesHandler.cpp
@@ -1,6 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/WorldStatesHandler.h
+++ b/src/arcemu-world/WorldStatesHandler.h
@@ -1,6 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/debugcmds.cpp
+++ b/src/arcemu-world/debugcmds.cpp
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/faction.cpp
+++ b/src/arcemu-world/faction.cpp
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/arcemu-world/faction.h
+++ b/src/arcemu-world/faction.h
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/scripts/src/Common/Base.cpp
+++ b/src/scripts/src/Common/Base.cpp
@@ -1,7 +1,7 @@
 /*
- * Moon++ Scripts for Ascent MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2007-2008 Moon++ Team <http://www.moonplusplus.info/>
+ * Moon++ Scripts for ArcEmu MMORPG Server
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2007-2008 Moon++ Team 
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/scripts/src/Common/Base.h
+++ b/src/scripts/src/Common/Base.h
@@ -1,7 +1,7 @@
 /*
- * Moon++ Scripts for Ascent MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2007-2008 Moon++ Team <http://www.moonplusplus.info/>
+ * Moon++ Scripts for ArcEmu MMORPG Server
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2007-2008 Moon++ Team 
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/scripts/src/Common/EasyFunctions.h
+++ b/src/scripts/src/Common/EasyFunctions.h
@@ -1,7 +1,7 @@
 /*
- * Moon++ Scripts for Ascent MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2007-2008 Moon++ Team <http://www.moonplusplus.info/>
+ * Moon++ Scripts for ArcEmu MMORPG Server
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2007-2008 Moon++ Team 
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/scripts/src/Common/Instance_Base.cpp
+++ b/src/scripts/src/Common/Instance_Base.cpp
@@ -1,7 +1,7 @@
 /*
- * Moon++ Scripts for Ascent MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2007-2008 Moon++ Team <http://www.moonplusplus.info/>
+ * Moon++ Scripts for ArcEmu MMORPG Server
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2007-2008 Moon++ Team 
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/scripts/src/Common/Instance_Base.h
+++ b/src/scripts/src/Common/Instance_Base.h
@@ -1,7 +1,7 @@
 /*
- * Moon++ Scripts for Ascent MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2007-2008 Moon++ Team <http://www.moonplusplus.info/>
+ * Moon++ Scripts for ArcEmu MMORPG Server
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2007-2008 Moon++ Team 
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/scripts/src/EventScripts/Setup.cpp
+++ b/src/scripts/src/EventScripts/Setup.cpp
@@ -1,6 +1,6 @@
 /*
- * Sun++ Scripts for Ascent MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
+ * Sun++ Scripts for ArcEmu MMORPG Server
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  * Copyright (C) 2007-2008 Moon++ Team <http://www.sunplusplus.info/>
  *
  * This program is free software: you can redistribute it and/or modify

--- a/src/scripts/src/EventScripts/Setup.h
+++ b/src/scripts/src/EventScripts/Setup.h
@@ -1,7 +1,7 @@
 /*
- * Moon++ Scripts for Ascent MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2007-2008 Moon++ Team <http://www.moonplusplus.info/>
+ * Moon++ Scripts for ArcEmu MMORPG Server
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2007-2008 Moon++ Team 
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/scripts/src/GossipScripts/Gossip_Guard.cpp
+++ b/src/scripts/src/GossipScripts/Gossip_Guard.cpp
@@ -1,7 +1,7 @@
 /*
- * Moon++ Scripts for Ascent MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2007-2008 Moon++ Team <http://www.moonplusplus.info/>
+ * Moon++ Scripts for ArcEmu MMORPG Server
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2007-2008 Moon++ Team 
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/scripts/src/GossipScripts/Gossip_Innkeepers.cpp
+++ b/src/scripts/src/GossipScripts/Gossip_Innkeepers.cpp
@@ -1,7 +1,7 @@
 /*
- * Moon++ Scripts for Ascent MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2007-2008 Moon++ Team <http://www.moonplusplus.info/>
+ * Moon++ Scripts for ArcEmu MMORPG Server
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2007-2008 Moon++ Team 
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/scripts/src/GossipScripts/Gossip_Moonglade.cpp
+++ b/src/scripts/src/GossipScripts/Gossip_Moonglade.cpp
@@ -1,6 +1,6 @@
 /*
- * Moon++ Scripts for Ascent MMORPG Server
- * Copyright (C) 2007-2008 Moon++ Team <http://www.moonplusplus.info/>
+ * Moon++ Scripts for ArcEmu MMORPG Server
+ * Copyright (C) 2007-2008 Moon++ Team 
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/scripts/src/GossipScripts/Gossip_Mulgore.cpp
+++ b/src/scripts/src/GossipScripts/Gossip_Mulgore.cpp
@@ -1,6 +1,6 @@
 /*
- * Moon++ Scripts for Ascent MMORPG Server
- * Copyright (C) 2007-2008 Moon++ Team <http://www.moonplusplus.info/>
+ * Moon++ Scripts for ArcEmu MMORPG Server
+ * Copyright (C) 2007-2008 Moon++ Team 
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/scripts/src/GossipScripts/Gossip_Shattrath.cpp
+++ b/src/scripts/src/GossipScripts/Gossip_Shattrath.cpp
@@ -1,6 +1,6 @@
 /*
- * Moon++ Scripts for Ascent MMORPG Server
- * Copyright (C) 2007-2008 Moon++ Team <http://www.moonplusplus.info/>
+ * Moon++ Scripts for ArcEmu MMORPG Server
+ * Copyright (C) 2007-2008 Moon++ Team 
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/scripts/src/GossipScripts/Gossip_Stormwind.cpp
+++ b/src/scripts/src/GossipScripts/Gossip_Stormwind.cpp
@@ -1,6 +1,6 @@
 /*
- * Moon++ Scripts for Ascent MMORPG Server
- * Copyright (C) 2007-2008 Moon++ Team <http://www.moonplusplus.info/>
+ * Moon++ Scripts for ArcEmu MMORPG Server
+ * Copyright (C) 2007-2008 Moon++ Team 
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/scripts/src/GossipScripts/Gossip_Tanaris.cpp
+++ b/src/scripts/src/GossipScripts/Gossip_Tanaris.cpp
@@ -1,6 +1,6 @@
 /*
- * Moon++ Scripts for Ascent MMORPG Server
- * Copyright (C) 2007-2008 Moon++ Team <http://www.moonplusplus.info/>
+ * Moon++ Scripts for ArcEmu MMORPG Server
+ * Copyright (C) 2007-2008 Moon++ Team 
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/scripts/src/GossipScripts/Gossip_Teldrassil.cpp
+++ b/src/scripts/src/GossipScripts/Gossip_Teldrassil.cpp
@@ -1,6 +1,6 @@
 /*
- * Moon++ Scripts for Ascent MMORPG Server
- * Copyright (C) 2007-2008 Moon++ Team <http://www.moonplusplus.info/>
+ * Moon++ Scripts for ArcEmu MMORPG Server
+ * Copyright (C) 2007-2008 Moon++ Team 
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/scripts/src/GossipScripts/Gossip_Theramore.cpp
+++ b/src/scripts/src/GossipScripts/Gossip_Theramore.cpp
@@ -1,6 +1,6 @@
 /*
- * Moon++ Scripts for Ascent MMORPG Server
- * Copyright (C) 2007-2008 Moon++ Team <http://www.moonplusplus.info/>
+ * Moon++ Scripts for ArcEmu MMORPG Server
+ * Copyright (C) 2007-2008 Moon++ Team 
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/scripts/src/GossipScripts/Gossip_Trainer.cpp
+++ b/src/scripts/src/GossipScripts/Gossip_Trainer.cpp
@@ -1,7 +1,7 @@
 /*
- * Moon++ Scripts for Ascent MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2007-2008 Moon++ Team <http://www.moonplusplus.info/>
+ * Moon++ Scripts for ArcEmu MMORPG Server
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2007-2008 Moon++ Team 
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/scripts/src/GossipScripts/Gossip_XpEliminator.cpp
+++ b/src/scripts/src/GossipScripts/Gossip_XpEliminator.cpp
@@ -1,6 +1,6 @@
 /*
- * Gossip scripts for Arcemu MMORPG Server
- * Copyright (C) 2008-2011 Arcemu Team <http://www.moonplusplus.info/>
+ * Gossip scripts for ArcEmu MMORPG Server
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/scripts/src/GossipScripts/Setup.cpp
+++ b/src/scripts/src/GossipScripts/Setup.cpp
@@ -1,7 +1,7 @@
 /*
- * Moon++ Scripts for Ascent MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2007-2008 Moon++ Team <http://www.moonplusplus.info/>
+ * Moon++ Scripts for ArcEmu MMORPG Server
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2007-2008 Moon++ Team 
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/scripts/src/GossipScripts/Setup.h
+++ b/src/scripts/src/GossipScripts/Setup.h
@@ -1,7 +1,7 @@
 /*
- * Moon++ Scripts for Ascent MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2007-2008 Moon++ Team <http://www.moonplusplus.info/>
+ * Moon++ Scripts for ArcEmu MMORPG Server
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2007-2008 Moon++ Team 
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/scripts/src/InstanceScripts/Instance_Arcatraz.cpp
+++ b/src/scripts/src/InstanceScripts/Instance_Arcatraz.cpp
@@ -1,9 +1,9 @@
 /*
  * ArcScripts for ArcEmu MMORPG Server
- * Copyright (C) 2009 ArcEmu Team <http://www.arcemu.org/>
- * Copyright (C) 2008-2009 Sun++ Team <http://www.sunscripting.com/>
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2007-2008 Moon++ Team <http://www.moonplusplus.info/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2008-2009 Sun++ Team
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2007-2008 Moon++ Team 
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/scripts/src/InstanceScripts/Instance_AuchenaiCrypts.cpp
+++ b/src/scripts/src/InstanceScripts/Instance_AuchenaiCrypts.cpp
@@ -1,9 +1,9 @@
 /*
  * ArcScripts for ArcEmu MMORPG Server
- * Copyright (C) 2009 ArcEmu Team <http://www.arcemu.org/>
- * Copyright (C) 2008-2009 Sun++ Team <http://www.sunscripting.com/>
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2007-2008 Moon++ Team <http://www.moonplusplus.info/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2008-2009 Sun++ Team
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2007-2008 Moon++ Team 
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/scripts/src/InstanceScripts/Instance_AzjolNerub.cpp
+++ b/src/scripts/src/InstanceScripts/Instance_AzjolNerub.cpp
@@ -1,9 +1,9 @@
 /*
 * ArcScripts for ArcEmu MMORPG Server
-* Copyright (C) 2009 ArcEmu Team <http://www.arcemu.org/>
-* Copyright (C) 2008-2009 Sun++ Team <http://www.sunscripting.com/>
-* Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
-* Copyright (C) 2007-2008 Moon++ Team <http://www.moonplusplus.info/>
+*  * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/> 
+* Copyright (C) 2008-2009 Sun++ Team
+* Copyright (C) 2008-2012 ArcEmu 
+* Copyright (C) 2007-2008 Moon++ Team 
 *
 * This program is free software: you can redistribute it and/or modify
 * it under the terms of the GNU General Public License as published by

--- a/src/scripts/src/InstanceScripts/Instance_BlackMorass.cpp
+++ b/src/scripts/src/InstanceScripts/Instance_BlackMorass.cpp
@@ -1,9 +1,9 @@
 /*
 * ArcScripts for ArcEmu MMORPG Server
-* Copyright (C) 2009 ArcEmu Team <http://www.arcemu.org/>
-* Copyright (C) 2008-2009 Sun++ Team <http://www.sunscripting.com/>
-* Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
-* Copyright (C) 2007-2008 Moon++ Team <http://www.moonplusplus.info/>
+*  * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/> 
+* Copyright (C) 2008-2009 Sun++ Team
+* Copyright (C) 2008-2012 ArcEmu 
+* Copyright (C) 2007-2008 Moon++ Team 
 *
 * This program is free software: you can redistribute it and/or modify
 * it under the terms of the GNU General Public License as published by

--- a/src/scripts/src/InstanceScripts/Instance_BlackfathomDeeps.cpp
+++ b/src/scripts/src/InstanceScripts/Instance_BlackfathomDeeps.cpp
@@ -1,7 +1,7 @@
 /*
  * ArcScripts for ArcEmu MMORPG Server
- * Copyright (C) 2009 ArcEmu Team <http://www.arcemu.org/>
- * Copyright (C) 2008-2009 Sun++ Team <http://www.sunscripting.com/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2008-2009 Sun++ Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/scripts/src/InstanceScripts/Instance_BlackrockDepths.cpp
+++ b/src/scripts/src/InstanceScripts/Instance_BlackrockDepths.cpp
@@ -1,9 +1,9 @@
 /*
  * ArcScripts for ArcEmu MMORPG Server
- * Copyright (C) 2009 ArcEmu Team <http://www.arcemu.org/>
- * Copyright (C) 2008-2009 Sun++ Team <http://www.sunscripting.com/>
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2007-2008 Moon++ Team <http://www.moonplusplus.info/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2008-2009 Sun++ Team
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2007-2008 Moon++ Team 
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/scripts/src/InstanceScripts/Instance_BlackrockSpire.cpp
+++ b/src/scripts/src/InstanceScripts/Instance_BlackrockSpire.cpp
@@ -1,9 +1,9 @@
 /*
  * ArcScripts for ArcEmu MMORPG Server
- * Copyright (C) 2009 ArcEmu Team <http://www.arcemu.org/>
- * Copyright (C) 2008-2009 Sun++ Team <http://www.sunscripting.com/>
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2007-2008 Moon++ Team <http://www.moonplusplus.info/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2008-2009 Sun++ Team
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2007-2008 Moon++ Team 
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/scripts/src/InstanceScripts/Instance_BloodFurnace.cpp
+++ b/src/scripts/src/InstanceScripts/Instance_BloodFurnace.cpp
@@ -1,9 +1,9 @@
 /*
  * ArcScripts for ArcEmu MMORPG Server
- * Copyright (C) 2009 ArcEmu Team <http://www.arcemu.org/>
- * Copyright (C) 2008-2009 Sun++ Team <http://www.sunscripting.com/>
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2007-2008 Moon++ Team <http://www.moonplusplus.info/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2008-2009 Sun++ Team
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2007-2008 Moon++ Team 
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/scripts/src/InstanceScripts/Instance_Botanica.cpp
+++ b/src/scripts/src/InstanceScripts/Instance_Botanica.cpp
@@ -1,9 +1,9 @@
 /*
  * ArcScripts for ArcEmu MMORPG Server
- * Copyright (C) 2009 ArcEmu Team <http://www.arcemu.org/>
- * Copyright (C) 2008-2009 Sun++ Team <http://www.sunscripting.com/>
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2007-2008 Moon++ Team <http://www.moonplusplus.info/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2008-2009 Sun++ Team
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2007-2008 Moon++ Team 
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/scripts/src/InstanceScripts/Instance_CullingOfStratholme.cpp
+++ b/src/scripts/src/InstanceScripts/Instance_CullingOfStratholme.cpp
@@ -1,7 +1,7 @@
 /*
  * ArcScripts for ArcEmu MMORPG Server
- * Copyright (C) 2009 ArcEmu Team <http://www.arcemu.org/>
- * Copyright (C) 2008-2009 Sun++ Team <http://www.sunscripting.com/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2008-2009 Sun++ Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/scripts/src/InstanceScripts/Instance_Deadmines.cpp
+++ b/src/scripts/src/InstanceScripts/Instance_Deadmines.cpp
@@ -1,9 +1,9 @@
 /*
  * ArcScripts for ArcEmu MMORPG Server
- * Copyright (C) 2009 ArcEmu Team <http://www.arcemu.org/>
- * Copyright (C) 2008-2009 Sun++ Team <http://www.sunscripting.com/>
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2007-2008 Moon++ Team <http://www.moonplusplus.info/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2008-2009 Sun++ Team
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2007-2008 Moon++ Team 
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/scripts/src/InstanceScripts/Instance_DireMaul.cpp
+++ b/src/scripts/src/InstanceScripts/Instance_DireMaul.cpp
@@ -1,9 +1,9 @@
 /*
  * ArcScripts for ArcEmu MMORPG Server
- * Copyright (C) 2009 ArcEmu Team <http://www.arcemu.org/>
- * Copyright (C) 2008-2009 Sun++ Team <http://www.sunscripting.com/>
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2007-2008 Moon++ Team <http://www.moonplusplus.info/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2008-2009 Sun++ Team
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2007-2008 Moon++ Team 
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/scripts/src/InstanceScripts/Instance_DrakTharonKeep.cpp
+++ b/src/scripts/src/InstanceScripts/Instance_DrakTharonKeep.cpp
@@ -1,7 +1,7 @@
 /*
  * ArcScripts for ArcEmu MMORPG Server
- * Copyright (C) 2009 ArcEmu Team <http://www.arcemu.org/>
- * Copyright (C) 2008-2009 Sun++ Team <http://www.sunscripting.com/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2008-2009 Sun++ Team
 *
 * This program is free software: you can redistribute it and/or modify
 * it under the terms of the GNU General Public License as published by

--- a/src/scripts/src/InstanceScripts/Instance_Gundrak.cpp
+++ b/src/scripts/src/InstanceScripts/Instance_Gundrak.cpp
@@ -1,6 +1,6 @@
 /*
  * ArcScripts for ArcEmu MMORPG Server
- * Copyright (C) 2010 ArcEmu Team <http://www.arcemu.org/>
+ * Copyright (C) 2010 ArcEmu Team 
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/scripts/src/InstanceScripts/Instance_HallsOfLightning.cpp
+++ b/src/scripts/src/InstanceScripts/Instance_HallsOfLightning.cpp
@@ -1,6 +1,6 @@
 /*
  * ArcScripts for ArcEmu MMORPG Server
- * Copyright (C) 2009-2010 ArcEmu Team <http://www.arcemu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/scripts/src/InstanceScripts/Instance_HallsOfStone.cpp
+++ b/src/scripts/src/InstanceScripts/Instance_HallsOfStone.cpp
@@ -1,7 +1,7 @@
 /*
  * ArcScripts for ArcEmu MMORPG Server
- * Copyright (C) 2009 ArcEmu Team <http://www.arcemu.org/>
- * Copyright (C) 2008-2009 Sun++ Team <http://www.sunscripting.com/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2008-2009 Sun++ Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/scripts/src/InstanceScripts/Instance_HellfireRamparts.cpp
+++ b/src/scripts/src/InstanceScripts/Instance_HellfireRamparts.cpp
@@ -1,9 +1,9 @@
 /*
  * ArcScripts for ArcEmu MMORPG Server
- * Copyright (C) 2009 ArcEmu Team <http://www.arcemu.org/>
- * Copyright (C) 2008-2009 Sun++ Team <http://www.sunscripting.com/>
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2007-2008 Moon++ Team <http://www.moonplusplus.info/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2008-2009 Sun++ Team
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2007-2008 Moon++ Team 
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/scripts/src/InstanceScripts/Instance_MagistersTerrace.cpp
+++ b/src/scripts/src/InstanceScripts/Instance_MagistersTerrace.cpp
@@ -1,9 +1,9 @@
 /*
  * ArcScripts for ArcEmu MMORPG Server
- * Copyright (C) 2009 ArcEmu Team <http://www.arcemu.org/>
- * Copyright (C) 2008-2009 Sun++ Team <http://www.sunscripting.com/>
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2007-2008 Moon++ Team <http://www.moonplusplus.info/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2008-2009 Sun++ Team
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2007-2008 Moon++ Team 
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/scripts/src/InstanceScripts/Instance_ManaTombs.cpp
+++ b/src/scripts/src/InstanceScripts/Instance_ManaTombs.cpp
@@ -1,9 +1,9 @@
 /*
  * ArcScripts for ArcEmu MMORPG Server
- * Copyright (C) 2009 ArcEmu Team <http://www.arcemu.org/>
- * Copyright (C) 2008-2009 Sun++ Team <http://www.sunscripting.com/>
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2007-2008 Moon++ Team <http://www.moonplusplus.info/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2008-2009 Sun++ Team
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2007-2008 Moon++ Team 
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/scripts/src/InstanceScripts/Instance_Mauradon.cpp
+++ b/src/scripts/src/InstanceScripts/Instance_Mauradon.cpp
@@ -1,9 +1,9 @@
 /*
  * ArcScripts for ArcEmu MMORPG Server
- * Copyright (C) 2009 ArcEmu Team <http://www.arcemu.org/>
- * Copyright (C) 2008-2009 Sun++ Team <http://www.sunscripting.com/>
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2007-2008 Moon++ Team <http://www.moonplusplus.info/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2008-2009 Sun++ Team
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2007-2008 Moon++ Team 
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/scripts/src/InstanceScripts/Instance_Nexus.cpp
+++ b/src/scripts/src/InstanceScripts/Instance_Nexus.cpp
@@ -1,7 +1,7 @@
 /*
  * ArcScripts for ArcEmu MMORPG Server
- * Copyright (C) 2009 ArcEmu Team <http://www.arcemu.org/>
- * Copyright (C) 2008-2009 Sun++ Team <http://www.sunscripting.com/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2008-2009 Sun++ Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/scripts/src/InstanceScripts/Instance_OldHillsbradFoothills.cpp
+++ b/src/scripts/src/InstanceScripts/Instance_OldHillsbradFoothills.cpp
@@ -1,6 +1,6 @@
 /*
 * ArcScripts for ArcEmu MMORPG Server
-* Copyright (C) 2010 ArcEmu Team <http://www.arcemu.org/>
+* Copyright (C) 2010 ArcEmu Team 
 *
 * This program is free software: you can redistribute it and/or modify
 * it under the terms of the GNU General Public License as published by

--- a/src/scripts/src/InstanceScripts/Instance_RagefireChasm.cpp
+++ b/src/scripts/src/InstanceScripts/Instance_RagefireChasm.cpp
@@ -1,9 +1,9 @@
 /*
  * ArcScripts for ArcEmu MMORPG Server
- * Copyright (C) 2009 ArcEmu Team <http://www.arcemu.org/>
- * Copyright (C) 2008-2009 Sun++ Team <http://www.sunscripting.com/>
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2007-2008 Moon++ Team <http://www.moonplusplus.info/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2008-2009 Sun++ Team
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2007-2008 Moon++ Team 
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/scripts/src/InstanceScripts/Instance_RazorfenDowns.cpp
+++ b/src/scripts/src/InstanceScripts/Instance_RazorfenDowns.cpp
@@ -1,9 +1,9 @@
 /*
  * ArcScripts for ArcEmu MMORPG Server
- * Copyright (C) 2009 ArcEmu Team <http://www.arcemu.org/>
- * Copyright (C) 2008-2009 Sun++ Team <http://www.sunscripting.com/>
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2007-2008 Moon++ Team <http://www.moonplusplus.info/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2008-2009 Sun++ Team
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2007-2008 Moon++ Team 
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/scripts/src/InstanceScripts/Instance_ScarletMonastery.cpp
+++ b/src/scripts/src/InstanceScripts/Instance_ScarletMonastery.cpp
@@ -1,9 +1,9 @@
 /*
  * ArcScripts for ArcEmu MMORPG Server
- * Copyright (C) 2009-2010 ArcEmu Team <http://www.arcemu.org/>
- * Copyright (C) 2008-2009 Sun++ Team <http://www.sunscripting.com/>
- * Copyright (C) 2007-2008 Moon++ Team <http://www.moonplusplus.info/>
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2008-2009 Sun++ Team
+ * Copyright (C) 2007-2008 Moon++ Team 
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/scripts/src/InstanceScripts/Instance_Scholomance.cpp
+++ b/src/scripts/src/InstanceScripts/Instance_Scholomance.cpp
@@ -1,9 +1,9 @@
 /*
  * ArcScripts for ArcEmu MMORPG Server
- * Copyright (C) 2009 ArcEmu Team <http://www.arcemu.org/>
- * Copyright (C) 2008-2009 Sun++ Team <http://www.sunscripting.com/>
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2007-2008 Moon++ Team <http://www.moonplusplus.info/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2008-2009 Sun++ Team
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2007-2008 Moon++ Team 
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/scripts/src/InstanceScripts/Instance_SethekkHalls.cpp
+++ b/src/scripts/src/InstanceScripts/Instance_SethekkHalls.cpp
@@ -1,9 +1,9 @@
 /*
  * ArcScripts for ArcEmu MMORPG Server
- * Copyright (C) 2009 ArcEmu Team <http://www.arcemu.org/>
- * Copyright (C) 2008-2009 Sun++ Team <http://www.sunscripting.com/>
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2007-2008 Moon++ Team <http://www.moonplusplus.info/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2008-2009 Sun++ Team
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2007-2008 Moon++ Team 
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/scripts/src/InstanceScripts/Instance_ShadowLabyrinth.cpp
+++ b/src/scripts/src/InstanceScripts/Instance_ShadowLabyrinth.cpp
@@ -1,9 +1,9 @@
 /*
  * ArcScripts for ArcEmu MMORPG Server
- * Copyright (C) 2009 ArcEmu Team <http://www.arcemu.org/>
- * Copyright (C) 2008-2009 Sun++ Team <http://www.sunscripting.com/>
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2007-2008 Moon++ Team <http://www.moonplusplus.info/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2008-2009 Sun++ Team
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2007-2008 Moon++ Team 
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/scripts/src/InstanceScripts/Instance_ShadowfangKeep.cpp
+++ b/src/scripts/src/InstanceScripts/Instance_ShadowfangKeep.cpp
@@ -1,9 +1,9 @@
 /*
  * ArcScripts for ArcEmu MMORPG Server
- * Copyright (C) 2009 ArcEmu Team <http://www.arcemu.org/>
- * Copyright (C) 2008-2009 Sun++ Team <http://www.sunscripting.com/>
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2007-2008 Moon++ Team <http://www.moonplusplus.info/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2008-2009 Sun++ Team
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2007-2008 Moon++ Team 
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/scripts/src/InstanceScripts/Instance_TheMechanar.cpp
+++ b/src/scripts/src/InstanceScripts/Instance_TheMechanar.cpp
@@ -1,9 +1,9 @@
 /*
  * ArcScripts for ArcEmu MMORPG Server
- * Copyright (C) 2009 ArcEmu Team <http://www.arcemu.org/>
- * Copyright (C) 2008-2009 Sun++ Team <http://www.sunscripting.com/>
- * Copyright (C) 2007-2008 Moon++ Team <http://www.moonplusplus.info/>
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2008-2009 Sun++ Team
+ * Copyright (C) 2007-2008 Moon++ Team 
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/scripts/src/InstanceScripts/Instance_TheShatteredHalls.cpp
+++ b/src/scripts/src/InstanceScripts/Instance_TheShatteredHalls.cpp
@@ -1,9 +1,9 @@
 /*
  * ArcScripts for ArcEmu MMORPG Server
- * Copyright (C) 2009 ArcEmu Team <http://www.arcemu.org/>
- * Copyright (C) 2008-2009 Sun++ Team <http://www.sunscripting.com/>
- * Copyright (C) 2007-2008 Moon++ Team <http://www.moonplusplus.info/>
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2008-2009 Sun++ Team
+ * Copyright (C) 2007-2008 Moon++ Team 
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/scripts/src/InstanceScripts/Instance_TheSlavePens.cpp
+++ b/src/scripts/src/InstanceScripts/Instance_TheSlavePens.cpp
@@ -1,9 +1,8 @@
 /*
  * ArcScripts for ArcEmu MMORPG Server
- * Copyright (C) 2009 ArcEmu Team <http://www.arcemu.org/>
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2007-2008 Moon++ Team <http://www.moonplusplus.info/>
- * Copyright (C) 2008-2009 Sun++ Team <http://www.sunscripting.com/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2007-2008 Moon++ Team 
+ * Copyright (C) 2008-2009 Sun++ Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/scripts/src/InstanceScripts/Instance_TheSteamvault.cpp
+++ b/src/scripts/src/InstanceScripts/Instance_TheSteamvault.cpp
@@ -1,9 +1,9 @@
 /*
  * ArcScripts for ArcEmu MMORPG Server
- * Copyright (C) 2009 ArcEmu Team <http://www.arcemu.org/>
- * Copyright (C) 2008-2009 Sun++ Team <http://www.sunscripting.com/>
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2007-2008 Moon++ Team <http://www.moonplusplus.info/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2008-2009 Sun++ Team
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2007-2008 Moon++ Team 
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/scripts/src/InstanceScripts/Instance_TheStockade.cpp
+++ b/src/scripts/src/InstanceScripts/Instance_TheStockade.cpp
@@ -1,9 +1,9 @@
 /*
  * ArcScripts for ArcEmu MMORPG Server
- * Copyright (C) 2009 ArcEmu Team <http://www.arcemu.org/>
- * Copyright (C) 2008-2009 Sun++ Team <http://www.sunscripting.com/>
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2007-2008 Moon++ Team <http://www.moonplusplus.info/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2008-2009 Sun++ Team
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2007-2008 Moon++ Team 
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/scripts/src/InstanceScripts/Instance_TheUnderbog.cpp
+++ b/src/scripts/src/InstanceScripts/Instance_TheUnderbog.cpp
@@ -1,9 +1,9 @@
 /*
  * ArcScripts for ArcEmu MMORPG Server
- * Copyright (C) 2009 ArcEmu Team <http://www.arcemu.org/>
- * Copyright (C) 2008-2009 Sun++ Team <http://www.sunscripting.com/>
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2007-2008 Moon++ Team <http://www.moonplusplus.info/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2008-2009 Sun++ Team
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2007-2008 Moon++ Team 
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/scripts/src/InstanceScripts/Instance_Uldaman.cpp
+++ b/src/scripts/src/InstanceScripts/Instance_Uldaman.cpp
@@ -1,9 +1,9 @@
 /*
  * ArcScripts for ArcEmu MMORPG Server
- * Copyright (C) 2009 ArcEmu Team <http://www.arcemu.org/>
- * Copyright (C) 2008-2009 Sun++ Team <http://www.sunscripting.com/>
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2007-2008 Moon++ Team <http://www.moonplusplus.info/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2008-2009 Sun++ Team
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2007-2008 Moon++ Team 
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/scripts/src/InstanceScripts/Instance_UtgardeKeep.cpp
+++ b/src/scripts/src/InstanceScripts/Instance_UtgardeKeep.cpp
@@ -1,7 +1,7 @@
 /*
  * ArcScripts for ArcEmu MMORPG Server
- * Copyright (C) 2009 ArcEmu Team <http://www.arcemu.org/>
- * Copyright (C) 2008-2009 Sun++ Team <http://www.sunscripting.com/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2008-2009 Sun++ Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/scripts/src/InstanceScripts/Instance_WailingCaverns.cpp
+++ b/src/scripts/src/InstanceScripts/Instance_WailingCaverns.cpp
@@ -1,9 +1,9 @@
 /*
  * ArcScripts for ArcEmu MMORPG Server
- * Copyright (C) 2009 ArcEmu Team <http://www.arcemu.org/>
- * Copyright (C) 2008-2009 Sun++ Team <http://www.sunscripting.com/>
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2007-2008 Moon++ Team <http://www.moonplusplus.info/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2008-2009 Sun++ Team
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2007-2008 Moon++ Team 
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/scripts/src/InstanceScripts/Instance_ZulFarrak.cpp
+++ b/src/scripts/src/InstanceScripts/Instance_ZulFarrak.cpp
@@ -1,9 +1,9 @@
 /*
  * ArcScripts for ArcEmu MMORPG Server
- * Copyright (C) 2009 ArcEmu Team <http://www.arcemu.org/>
- * Copyright (C) 2008-2009 Sun++ Team <http://www.sunscripting.com/>
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2007-2008 Moon++ Team <http://www.moonplusplus.info/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2008-2009 Sun++ Team
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2007-2008 Moon++ Team 
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/scripts/src/InstanceScripts/Raid_BlackTemple.cpp
+++ b/src/scripts/src/InstanceScripts/Raid_BlackTemple.cpp
@@ -1,9 +1,9 @@
 /*
  * ArcScripts for ArcEmu MMORPG Server
- * Copyright (C) 2009 ArcEmu Team <http://www.arcemu.org/>
- * Copyright (C) 2008-2009 Sun++ Team <http://www.sunscripting.com/>
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2007-2008 Moon++ Team <http://www.moonplusplus.info/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2008-2009 Sun++ Team
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2007-2008 Moon++ Team 
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/scripts/src/InstanceScripts/Raid_BlackwingLair.cpp
+++ b/src/scripts/src/InstanceScripts/Raid_BlackwingLair.cpp
@@ -1,9 +1,9 @@
 /*
  * ArcScripts for ArcEmu MMORPG Server
- * Copyright (C) 2009 ArcEmu Team <http://www.arcemu.org/>
- * Copyright (C) 2008-2009 Sun++ Team <http://www.sunscripting.com/>
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2007-2008 Moon++ Team <http://www.moonplusplus.info/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2008-2009 Sun++ Team
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2007-2008 Moon++ Team 
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/scripts/src/InstanceScripts/Raid_CoT_BattleOfMountHyjal.cpp
+++ b/src/scripts/src/InstanceScripts/Raid_CoT_BattleOfMountHyjal.cpp
@@ -1,9 +1,9 @@
 /*
  * ArcScripts for ArcEmu MMORPG Server
- * Copyright (C) 2009 ArcEmu Team <http://www.arcemu.org/>
- * Copyright (C) 2008-2009 Sun++ Team <http://www.sunscripting.com/>
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2007-2008 Moon++ Team <http://www.moonplusplus.info/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2008-2009 Sun++ Team
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2007-2008 Moon++ Team 
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/scripts/src/InstanceScripts/Raid_GruulsLair.cpp
+++ b/src/scripts/src/InstanceScripts/Raid_GruulsLair.cpp
@@ -1,9 +1,9 @@
 /*
  * ArcScripts for ArcEmu MMORPG Server
- * Copyright (C) 2009 ArcEmu Team <http://www.arcemu.org/>
- * Copyright (C) 2008-2009 Sun++ Team <http://www.sunscripting.com/>
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2007-2008 Moon++ Team <http://www.moonplusplus.info/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2008-2009 Sun++ Team
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2007-2008 Moon++ Team 
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/scripts/src/InstanceScripts/Raid_Karazhan.cpp
+++ b/src/scripts/src/InstanceScripts/Raid_Karazhan.cpp
@@ -1,9 +1,9 @@
 /*
  * ArcScripts for ArcEmu MMORPG Server
- * Copyright (C) 2009 ArcEmu Team <http://www.arcemu.org/>
- * Copyright (C) 2008-2009 Sun++ Team <http://www.sunscripting.com/>
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2007-2008 Moon++ Team <http://www.moonplusplus.info/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2008-2009 Sun++ Team
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2007-2008 Moon++ Team 
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/scripts/src/InstanceScripts/Raid_Magtheridons_Lair.cpp
+++ b/src/scripts/src/InstanceScripts/Raid_Magtheridons_Lair.cpp
@@ -1,9 +1,9 @@
 /*
  * ArcScripts for ArcEmu MMORPG Server
- * Copyright (C) 2009 ArcEmu Team <http://www.arcemu.org/>
- * Copyright (C) 2008-2009 Sun++ Team <http://www.sunscripting.com/>
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2007-2008 Moon++ Team <http://www.moonplusplus.info/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2008-2009 Sun++ Team
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2007-2008 Moon++ Team 
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/scripts/src/InstanceScripts/Raid_MoltenCore.cpp
+++ b/src/scripts/src/InstanceScripts/Raid_MoltenCore.cpp
@@ -1,9 +1,9 @@
 /*
  * ArcScripts for ArcEmu MMORPG Server
- * Copyright (C) 2009 ArcEmu Team <http://www.arcemu.org/>
- * Copyright (C) 2008-2009 Sun++ Team <http://www.sunscripting.com/>
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2007-2008 Moon++ Team <http://www.moonplusplus.info/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2008-2009 Sun++ Team
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2007-2008 Moon++ Team 
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/scripts/src/InstanceScripts/Raid_Naxxramas.cpp
+++ b/src/scripts/src/InstanceScripts/Raid_Naxxramas.cpp
@@ -1,7 +1,7 @@
 /*
  * ArcScripts for ArcEmu MMORPG Server
- * Copyright (C) 2009 ArcEmu Team <http://www.arcemu.org/>
- * Copyright (C) 2008-2009 Sun++ Team <http://www.sunscripting.com/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2008-2009 Sun++ Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/scripts/src/InstanceScripts/Raid_Naxxramas.h
+++ b/src/scripts/src/InstanceScripts/Raid_Naxxramas.h
@@ -1,7 +1,7 @@
 /*
  * ArcScripts for ArcEmu MMORPG Server
- * Copyright (C) 2009 ArcEmu Team <http://www.arcemu.org/>
- * Copyright (C) 2008-2009 Sun++ Team <http://www.sunscripting.com/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2008-2009 Sun++ Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/scripts/src/InstanceScripts/Raid_OnyxiasLair.cpp
+++ b/src/scripts/src/InstanceScripts/Raid_OnyxiasLair.cpp
@@ -1,9 +1,9 @@
 /*
  * ArcScripts for ArcEmu MMORPG Server
- * Copyright (C) 2009 ArcEmu Team <http://www.arcemu.org/>
- * Copyright (C) 2008-2009 Sun++ Team <http://www.sunscripting.com/>
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2007-2008 Moon++ Team <http://www.moonplusplus.info/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2008-2009 Sun++ Team
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2007-2008 Moon++ Team 
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/scripts/src/InstanceScripts/Raid_SerpentshrineCavern.cpp
+++ b/src/scripts/src/InstanceScripts/Raid_SerpentshrineCavern.cpp
@@ -1,9 +1,9 @@
 /*
  * ArcScripts for ArcEmu MMORPG Server
- * Copyright (C) 2009 ArcEmu Team <http://www.arcemu.org/>
- * Copyright (C) 2008-2009 Sun++ Team <http://www.sunscripting.com/>
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2007-2008 Moon++ Team <http://www.moonplusplus.info/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2008-2009 Sun++ Team
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2007-2008 Moon++ Team 
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/scripts/src/InstanceScripts/Raid_TheEye.cpp
+++ b/src/scripts/src/InstanceScripts/Raid_TheEye.cpp
@@ -1,9 +1,9 @@
 /*
  * ArcScripts for ArcEmu MMORPG Server
- * Copyright (C) 2009 ArcEmu Team <http://www.arcemu.org/>
- * Copyright (C) 2008-2009 Sun++ Team <http://www.sunscripting.com/>
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2007-2008 Moon++ Team <http://www.moonplusplus.info/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2008-2009 Sun++ Team
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2007-2008 Moon++ Team 
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/scripts/src/InstanceScripts/Raid_TheObsidianSanctum.cpp
+++ b/src/scripts/src/InstanceScripts/Raid_TheObsidianSanctum.cpp
@@ -1,7 +1,7 @@
 /*
  * ArcScripts for ArcEmu MMORPG Server
- * Copyright (C) 2009 ArcEmu Team <http://www.arcemu.org/>
- * Copyright (C) 2008-2009 Sun++ Team <http://www.sunscripting.com/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2008-2009 Sun++ Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/scripts/src/InstanceScripts/Raid_Ulduar.cpp
+++ b/src/scripts/src/InstanceScripts/Raid_Ulduar.cpp
@@ -1,7 +1,7 @@
 /*
  * ArcScripts for ArcEmu MMORPG Server
- * Copyright (C) 2009 ArcEmu Team <http://www.arcemu.org/>
- * Copyright (C) 2008-2009 Sun++ Team <http://www.sunscripting.com/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2008-2009 Sun++ Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/scripts/src/InstanceScripts/Raid_Ulduar.h
+++ b/src/scripts/src/InstanceScripts/Raid_Ulduar.h
@@ -1,7 +1,7 @@
 /*
  * ArcScripts for ArcEmu MMORPG Server
- * Copyright (C) 2009 ArcEmu Team <http://www.arcemu.org/>
- * Copyright (C) 2008-2009 Sun++ Team <http://www.sunscripting.com/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2008-2009 Sun++ Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/scripts/src/InstanceScripts/Raid_WorldBosses.cpp
+++ b/src/scripts/src/InstanceScripts/Raid_WorldBosses.cpp
@@ -1,9 +1,9 @@
 /*
  * ArcScripts for ArcEmu MMORPG Server
- * Copyright (C) 2009 ArcEmu Team <http://www.arcemu.org/>
- * Copyright (C) 2008-2009 Sun++ Team <http://www.sunscripting.com/>
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2007-2008 Moon++ Team <http://www.moonplusplus.info/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2008-2009 Sun++ Team
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2007-2008 Moon++ Team 
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/scripts/src/InstanceScripts/Raid_ZulAman.cpp
+++ b/src/scripts/src/InstanceScripts/Raid_ZulAman.cpp
@@ -1,9 +1,9 @@
 /*
  * ArcScripts for ArcEmu MMORPG Server
- * Copyright (C) 2009 ArcEmu Team <http://www.arcemu.org/>
- * Copyright (C) 2008-2009 Sun++ Team <http://www.sunscripting.com/>
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2007-2008 Moon++ Team <http://www.moonplusplus.info/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2008-2009 Sun++ Team
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2007-2008 Moon++ Team 
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/scripts/src/InstanceScripts/Raid_ZulGurub.cpp
+++ b/src/scripts/src/InstanceScripts/Raid_ZulGurub.cpp
@@ -1,9 +1,9 @@
 /*
  * ArcScripts for ArcEmu MMORPG Server
- * Copyright (C) 2009 ArcEmu Team <http://www.arcemu.org/>
- * Copyright (C) 2008-2009 Sun++ Team <http://www.sunscripting.com/>
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2007-2008 Moon++ Team <http://www.moonplusplus.info/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2008-2009 Sun++ Team
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2007-2008 Moon++ Team 
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/scripts/src/InstanceScripts/SUNWELL_PLAT/Raid_SunwellPlateau.cpp
+++ b/src/scripts/src/InstanceScripts/SUNWELL_PLAT/Raid_SunwellPlateau.cpp
@@ -1,9 +1,9 @@
 /*
  * ArcScripts for ArcEmu MMORPG Server
- * Copyright (C) 2009 ArcEmu Team <http://www.arcemu.org/>
- * Copyright (C) 2008-2009 Sun++ Team <http://www.sunscripting.com/>
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2007-2008 Moon++ Team <http://www.moonplusplus.info/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2008-2009 Sun++ Team
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2007-2008 Moon++ Team 
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/scripts/src/InstanceScripts/Setup.cpp
+++ b/src/scripts/src/InstanceScripts/Setup.cpp
@@ -1,6 +1,6 @@
 /*
  * ArcScripts for ArcEmu MMORPG Server
- * Copyright (C) 2009 ArcEmu Team <http://www.arcemu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/scripts/src/InstanceScripts/Setup.h
+++ b/src/scripts/src/InstanceScripts/Setup.h
@@ -1,6 +1,6 @@
 /*
  * ArcScripts for ArcEmu MMORPG Server
- * Copyright (C) 2009 ArcEmu Team <http://www.arcemu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/scripts/src/LuaEngine/AuraFunctions.h
+++ b/src/scripts/src/LuaEngine/AuraFunctions.h
@@ -1,7 +1,7 @@
 /*
- * ArcScript Scripts for Arcemu MMORPG Server
- * Copyright (C) 2008-2011 Arcemu Team
- * Copyright (C) 2007 Moon++ <http://www.moonplusplus.com/>
+ * ArcScript Scripts for ArcEmu MMORPG Server
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2007 Moon++
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/scripts/src/LuaEngine/FunctionTables.h
+++ b/src/scripts/src/LuaEngine/FunctionTables.h
@@ -1,7 +1,7 @@
 /*
- * ArcScript Scripts for Arcemu MMORPG Server
- * Copyright (C) 2008-2011 Arcemu Team
- * Copyright (C) 2007 Moon++ <http://www.moonplusplus.com/>
+ * ArcScript Scripts for ArcEmu MMORPG Server
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2007 Moon++
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/scripts/src/LuaEngine/GameobjectFunctions.h
+++ b/src/scripts/src/LuaEngine/GameobjectFunctions.h
@@ -1,7 +1,7 @@
 /*
- * ArcScript Scripts for Arcemu MMORPG Server
- * Copyright (C) 2008-2011 Arcemu Team
- * Copyright (C) 2007 Moon++ <http://www.moonplusplus.com/>
+ * ArcScript Scripts for ArcEmu MMORPG Server
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2007 Moon++
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/scripts/src/LuaEngine/GlobalFunctions.h
+++ b/src/scripts/src/LuaEngine/GlobalFunctions.h
@@ -1,7 +1,7 @@
 /*
- * ArcScript Scripts for Arcemu MMORPG Server
- * Copyright (C) 2008-2011 Arcemu Team
- * Copyright (C) 2007 Moon++ <http://www.moonplusplus.com/>
+ * ArcScript Scripts for ArcEmu MMORPG Server
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2007 Moon++
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/scripts/src/LuaEngine/ItemFunctions.h
+++ b/src/scripts/src/LuaEngine/ItemFunctions.h
@@ -1,7 +1,7 @@
 /*
- * ArcScript Scripts for Arcemu MMORPG Server
- * Copyright (C) 2008-2011 Arcemu Team
- * Copyright (C) 2007 Moon++ <http://www.moonplusplus.com/>
+ * ArcScript Scripts for ArcEmu MMORPG Server
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2007 Moon++
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/scripts/src/LuaEngine/LUAEngine.cpp
+++ b/src/scripts/src/LuaEngine/LUAEngine.cpp
@@ -1,7 +1,7 @@
 /*
- * ArcScript Scripts for Arcemu MMORPG Server
- * Copyright (C) 2008-2011 Arcemu Team
- * Copyright (C) 2007 Moon++ <http://www.moonplusplus.com/>
+ * ArcScript Scripts for ArcEmu MMORPG Server
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2007 Moon++
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/scripts/src/LuaEngine/LUAEngine.h
+++ b/src/scripts/src/LuaEngine/LUAEngine.h
@@ -1,7 +1,7 @@
 /*
- * ArcScript Scripts for Arcemu MMORPG Server
- * Copyright (C) 2008-2011 Arcemu Team
- * Copyright (C) 2007 Moon++ <http://www.moonplusplus.com/>
+ * ArcScript Scripts for ArcEmu MMORPG Server
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2007 Moon++
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/scripts/src/LuaEngine/LUAFunctions.h
+++ b/src/scripts/src/LuaEngine/LUAFunctions.h
@@ -1,7 +1,7 @@
 /*
- * ArcScript Scripts for Arcemu MMORPG Server
- * Copyright (C) 2008-2011 Arcemu Team
- * Copyright (C) 2007 Moon++ <http://www.moonplusplus.com/>
+ * ArcScript Scripts for ArcEmu MMORPG Server
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2007 Moon++
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/scripts/src/LuaEngine/LuaSqlApi.h
+++ b/src/scripts/src/LuaEngine/LuaSqlApi.h
@@ -1,7 +1,7 @@
 /*
- * ArcScript Scripts for Arcemu MMORPG Server
- * Copyright (C) 2008-2011 Arcemu Team
- * Copyright (C) 2007 Moon++ <http://www.moonplusplus.com/>
+ * ArcScript Scripts for ArcEmu MMORPG Server
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2007 Moon++
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/scripts/src/LuaEngine/PacketFunctions.h
+++ b/src/scripts/src/LuaEngine/PacketFunctions.h
@@ -1,7 +1,7 @@
 /*
- * ArcScript Scripts for Arcemu MMORPG Server
- * Copyright (C) 2008-2011 Arcemu Team
- * Copyright (C) 2007 Moon++ <http://www.moonplusplus.com/>
+ * ArcScript Scripts for ArcEmu MMORPG Server
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2007 Moon++
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/scripts/src/LuaEngine/SpellFunctions.h
+++ b/src/scripts/src/LuaEngine/SpellFunctions.h
@@ -1,7 +1,7 @@
 /*
- * ArcScript Scripts for Arcemu MMORPG Server
- * Copyright (C) 2008-2011 Arcemu Team
- * Copyright (C) 2007 Moon++ <http://www.moonplusplus.com/>
+ * ArcScript Scripts for ArcEmu MMORPG Server
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2007 Moon++
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/scripts/src/LuaEngine/TaxiFunctions.h
+++ b/src/scripts/src/LuaEngine/TaxiFunctions.h
@@ -1,7 +1,7 @@
 /*
- * ArcScript Scripts for Arcemu MMORPG Server
- * Copyright (C) 2008-2011 Arcemu Team
- * Copyright (C) 2007 Moon++ <http://www.moonplusplus.com/>
+ * ArcScript Scripts for ArcEmu MMORPG Server
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2007 Moon++
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/scripts/src/LuaEngine/UnitFunctions.h
+++ b/src/scripts/src/LuaEngine/UnitFunctions.h
@@ -1,7 +1,7 @@
 /*
- * ArcScript Scripts for Arcemu MMORPG Server
- * Copyright (C) 2008-2011 Arcemu Team
- * Copyright (C) 2007 Moon++ <http://www.moonplusplus.com/>
+ * ArcScript Scripts for ArcEmu MMORPG Server
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2007 Moon++
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/scripts/src/MiscScripts/Creatures.cpp
+++ b/src/scripts/src/MiscScripts/Creatures.cpp
@@ -1,7 +1,7 @@
 /*
-* Moon++ Scripts for Ascent MMORPG Server
-* Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
-* Copyright (C) 2007-2008 Moon++ Team <http://www.moonplusplus.info/>
+* Moon++ Scripts for ArcEmu MMORPG Server
+* Copyright (C) 2008-2012 ArcEmu 
+* Copyright (C) 2007-2008 Moon++ Team 
 *
 * This program is free software: you can redistribute it and/or modify
 * it under the terms of the GNU General Public License as published by

--- a/src/scripts/src/MiscScripts/GameObjectTeleportTable.cpp
+++ b/src/scripts/src/MiscScripts/GameObjectTeleportTable.cpp
@@ -1,7 +1,7 @@
 /*
- * ArcScript Scripts for Arcemu MMORPG Server
- * Copyright (C) 2008-2011 Arcemu Team
- * Copyright (C) 2007 Moon++ <http://www.moonplusplus.com/>
+ * ArcScript Scripts for ArcEmu MMORPG Server
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2007 Moon++
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/scripts/src/MiscScripts/GameObjects.cpp
+++ b/src/scripts/src/MiscScripts/GameObjects.cpp
@@ -1,7 +1,7 @@
 /*
- * Moon++ Scripts for Ascent MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2007-2008 Moon++ Team <http://www.moonplusplus.info/>
+ * Moon++ Scripts for ArcEmu MMORPG Server
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2007-2008 Moon++ Team 
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/scripts/src/MiscScripts/RandomScripts.cpp
+++ b/src/scripts/src/MiscScripts/RandomScripts.cpp
@@ -1,7 +1,7 @@
 /*
- * Moon++ Scripts for Ascent MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2007-2008 Moon++ Team <http://www.moonplusplus.info/>
+ * Moon++ Scripts for ArcEmu MMORPG Server
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2007-2008 Moon++ Team 
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/scripts/src/MiscScripts/Setup.cpp
+++ b/src/scripts/src/MiscScripts/Setup.cpp
@@ -1,7 +1,7 @@
 /*
- * Moon++ Scripts for Ascent MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2007-2008 Moon++ Team <http://www.moonplusplus.info/>
+ * Moon++ Scripts for ArcEmu MMORPG Server
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2007-2008 Moon++ Team 
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/scripts/src/MiscScripts/Setup.h
+++ b/src/scripts/src/MiscScripts/Setup.h
@@ -1,7 +1,7 @@
 /*
- * Moon++ Scripts for Ascent MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2007-2008 Moon++ Team <http://www.moonplusplus.info/>
+ * Moon++ Scripts for ArcEmu MMORPG Server
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2007-2008 Moon++ Team 
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/scripts/src/QuestScripts/QuestGossip.cpp
+++ b/src/scripts/src/QuestScripts/QuestGossip.cpp
@@ -1,7 +1,7 @@
 /*
  * ArcScripts for ArcEmu MMORPG Server
- * Copyright (C) 2009 ArcEmu Team <http://www.arcemu.org/>
- * Copyright (C) 2008-2009 Sun++ Team <http://www.sunscripting.com/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2008-2009 Sun++ Team
  * Copyright (C) 2008 WEmu Team
  * Copyright (C) 2009 WhyScripts Team <http://www.whydb.org/>
  *

--- a/src/scripts/src/QuestScripts/QuestHooks.cpp
+++ b/src/scripts/src/QuestScripts/QuestHooks.cpp
@@ -1,7 +1,7 @@
 /*
  * ArcScripts for ArcEmu MMORPG Server
- * Copyright (C) 2009 ArcEmu Team <http://www.arcemu.org/>
- * Copyright (C) 2008-2009 Sun++ Team <http://www.sunscripting.com/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2008-2009 Sun++ Team
  * Copyright (C) 2008 WEmu Team
  *
  * Script by Fer0x

--- a/src/scripts/src/QuestScripts/Quest_ArathiHighlands.cpp
+++ b/src/scripts/src/QuestScripts/Quest_ArathiHighlands.cpp
@@ -1,7 +1,7 @@
 /*
  * ArcScripts for ArcEmu MMORPG Server
- * Copyright (C) 2009 ArcEmu Team <http://www.arcemu.org/>
- * Copyright (C) 2008-2009 Sun++ Team <http://www.sunscripting.com/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2008-2009 Sun++ Team
  * Copyright (C) 2008 WEmu Team
  *
  * This program is free software: you can redistribute it and/or modify

--- a/src/scripts/src/QuestScripts/Quest_Azshara.cpp
+++ b/src/scripts/src/QuestScripts/Quest_Azshara.cpp
@@ -1,7 +1,7 @@
 /*
  * ArcScripts for ArcEmu MMORPG Server
- * Copyright (C) 2009 ArcEmu Team <http://www.arcemu.org/>
- * Copyright (C) 2008-2009 Sun++ Team <http://www.sunscripting.com/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2008-2009 Sun++ Team
  * Copyright (C) 2008 WEmu Team
  *
  * This program is free software: you can redistribute it and/or modify

--- a/src/scripts/src/QuestScripts/Quest_Azuremyst_Isle.cpp
+++ b/src/scripts/src/QuestScripts/Quest_Azuremyst_Isle.cpp
@@ -1,7 +1,7 @@
 /*
  * ArcScripts for ArcEmu MMORPG Server
- * Copyright (C) 2009 ArcEmu Team <http://www.arcemu.org/>
- * Copyright (C) 2008-2009 Sun++ Team <http://www.sunscripting.com/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2008-2009 Sun++ Team
  * Copyright (C) 2008 WEmu Team
  * Copyright (C) 2007-2008 Moon++ Team
  *

--- a/src/scripts/src/QuestScripts/Quest_BladeEdge_Mountains.cpp
+++ b/src/scripts/src/QuestScripts/Quest_BladeEdge_Mountains.cpp
@@ -1,9 +1,8 @@
 /*
  * ArcScripts for ArcEmu MMORPG Server
- * Copyright (C) 2009 ArcEmu Team <http://www.arcemu.org/>
- * Copyright (C) 2008-2009 Sun++ Team <http://www.sunscripting.com/>
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2007-2008 Moon++ Team <http://www.moonplusplus.info/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2008-2009 Sun++ Team
+ * Copyright (C) 2007-2008 Moon++ Team 
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/scripts/src/QuestScripts/Quest_BlastedLands.cpp
+++ b/src/scripts/src/QuestScripts/Quest_BlastedLands.cpp
@@ -1,7 +1,7 @@
 /*
  * ArcScripts for ArcEmu MMORPG Server
- * Copyright (C) 2009 ArcEmu Team <http://www.arcemu.org/>
- * Copyright (C) 2008-2009 Sun++ Team <http://www.sunscripting.com/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2008-2009 Sun++ Team
  * Copyright (C) 2008 WEmu Team
  *
  * This program is free software: you can redistribute it and/or modify

--- a/src/scripts/src/QuestScripts/Quest_BloodmystIsle.cpp
+++ b/src/scripts/src/QuestScripts/Quest_BloodmystIsle.cpp
@@ -1,7 +1,7 @@
 /*
  * ArcScripts for ArcEmu MMORPG Server
- * Copyright (C) 2009 ArcEmu Team <http://www.arcemu.org/>
- * Copyright (C) 2008-2009 Sun++ Team <http://www.sunscripting.com/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2008-2009 Sun++ Team
  * Copyright (C) 2008 WEmu Team
  *
  * This program is free software: you can redistribute it and/or modify

--- a/src/scripts/src/QuestScripts/Quest_BoreanTundra.cpp
+++ b/src/scripts/src/QuestScripts/Quest_BoreanTundra.cpp
@@ -1,6 +1,6 @@
 /*
  * ArcScripts for ArcEmu MMORPG Server
- * Copyright (C) 2009 ArcEmu Team <http://www.arcemu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/scripts/src/QuestScripts/Quest_BurningSteppes.cpp
+++ b/src/scripts/src/QuestScripts/Quest_BurningSteppes.cpp
@@ -1,5 +1,5 @@
 /*
- * Why Scripts for Arcemu MMORPG Server <http://www.arcemu.org/>
+ * Why Scripts for ArcEmu MMORPG Server 
  * Copyright (C) 2009 WhyScripts Team <http://www.whydb.org/>
  *
  * This program is free software: you can redistribute it and/or modify

--- a/src/scripts/src/QuestScripts/Quest_DeathKnight.cpp
+++ b/src/scripts/src/QuestScripts/Quest_DeathKnight.cpp
@@ -1,7 +1,7 @@
 /*
  * ArcScripts for ArcEmu MMORPG Server
- * Copyright (C) 2009 ArcEmu Team <http://www.arcemu.org/>
- * Copyright (C) 2008-2009 Sun++ Team <http://www.sunscripting.com/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2008-2009 Sun++ Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/scripts/src/QuestScripts/Quest_Desolace.cpp
+++ b/src/scripts/src/QuestScripts/Quest_Desolace.cpp
@@ -1,7 +1,7 @@
 /*
  * ArcScripts for ArcEmu MMORPG Server
- * Copyright (C) 2009 ArcEmu Team <http://www.arcemu.org/>
- * Copyright (C) 2008-2009 Sun++ Team <http://www.sunscripting.com/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2008-2009 Sun++ Team
  * Copyright (C) 2008 WEmu Team
  *
  * This program is free software: you can redistribute it and/or modify

--- a/src/scripts/src/QuestScripts/Quest_Dragonblight.cpp
+++ b/src/scripts/src/QuestScripts/Quest_Dragonblight.cpp
@@ -1,7 +1,7 @@
 /*
  * ArcScripts for ArcEmu MMORPG Server
- * Copyright (C) 2009 ArcEmu Team <http://www.arcemu.org/>
- * Copyright (C) 2008-2009 Sun++ Team <http://www.sunscripting.com/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2008-2009 Sun++ Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/scripts/src/QuestScripts/Quest_Druid.cpp
+++ b/src/scripts/src/QuestScripts/Quest_Druid.cpp
@@ -1,9 +1,8 @@
 /*
  * ArcScripts for ArcEmu MMORPG Server
- * Copyright (C) 2009 ArcEmu Team <http://www.arcemu.org/>
- * Copyright (C) 2008-2009 Sun++ Team <http://www.sunscripting.com/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2008-2009 Sun++ Team
  * Copyright (C) 2008 WEmu Team
- * Copyright (C) 2005-2008 Ascent Team
  * Copyright (C) 2007-2008 Moon++ Team
  *
  * This program is free software: you can redistribute it and/or modify

--- a/src/scripts/src/QuestScripts/Quest_Duskwood.cpp
+++ b/src/scripts/src/QuestScripts/Quest_Duskwood.cpp
@@ -1,7 +1,7 @@
 /*
  * ArcScripts for ArcEmu MMORPG Server
- * Copyright (C) 2009 ArcEmu Team <http://www.arcemu.org/>
- * Copyright (C) 2008-2009 Sun++ Team <http://www.sunscripting.com/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2008-2009 Sun++ Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/scripts/src/QuestScripts/Quest_Dustwallow_Marsh.cpp
+++ b/src/scripts/src/QuestScripts/Quest_Dustwallow_Marsh.cpp
@@ -1,7 +1,7 @@
 /*
  * ArcScripts for ArcEmu MMORPG Server
- * Copyright (C) 2009 ArcEmu Team <http://www.arcemu.org/>
- * Copyright (C) 2008-2009 Sun++ Team <http://www.sunscripting.com/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2008-2009 Sun++ Team
  * Copyright (C) 2008 WEmu Team
  *
  * This program is free software: you can redistribute it and/or modify

--- a/src/scripts/src/QuestScripts/Quest_Eastern_Plaguelands.cpp
+++ b/src/scripts/src/QuestScripts/Quest_Eastern_Plaguelands.cpp
@@ -1,9 +1,8 @@
 /*
  * ArcScripts for ArcEmu MMORPG Server
- * Copyright (C) 2009 ArcEmu Team <http://www.arcemu.org/>
- * Copyright (C) 2008-2009 Sun++ Team <http://www.sunscripting.com/>
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2007-2008 Moon++ Team <http://www.moonplusplus.info/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2008-2009 Sun++ Team
+ * Copyright (C) 2007-2008 Moon++ Team 
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/scripts/src/QuestScripts/Quest_EversongWoods.cpp
+++ b/src/scripts/src/QuestScripts/Quest_EversongWoods.cpp
@@ -1,10 +1,9 @@
 /*
  * ArcScripts for ArcEmu MMORPG Server
- * Copyright (C) 2009 ArcEmu Team <http://www.arcemu.org/>
- * Copyright (C) 2008-2009 Sun++ Team <http://www.sunscripting.com/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2008-2009 Sun++ Team
  * Copyright (C) 2009 WhyScripts Team <http://www.whydb.org/>
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentcommunity.com/>
- * Copyright (C) 2007-2008 Moon++ Team <http://sunplusplus.info//>
+ * Copyright (C) 2007-2008 Moon++ Team 
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/scripts/src/QuestScripts/Quest_FirstAid.cpp
+++ b/src/scripts/src/QuestScripts/Quest_FirstAid.cpp
@@ -1,7 +1,7 @@
 /*
  * ArcScripts for ArcEmu MMORPG Server
- * Copyright (C) 2009 ArcEmu Team <http://www.arcemu.org/>
- * Copyright (C) 2008-2009 Sun++ Team <http://www.sunscripting.com/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2008-2009 Sun++ Team
  * Copyright (C) 2008 WEmu Team
  *
  * This program is free software: you can redistribute it and/or modify

--- a/src/scripts/src/QuestScripts/Quest_Ghostlands.cpp
+++ b/src/scripts/src/QuestScripts/Quest_Ghostlands.cpp
@@ -1,7 +1,7 @@
 /*
  * ArcScripts for ArcEmu MMORPG Server
- * Copyright (C) 2009 ArcEmu Team <http://www.arcemu.org/>
- * Copyright (C) 2008-2009 Sun++ Team <http://www.sunscripting.com/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2008-2009 Sun++ Team
  * Copyright (C) 2008 WEmu Team
  *
  * This program is free software: you can redistribute it and/or modify

--- a/src/scripts/src/QuestScripts/Quest_Hellfire_Peninsula.cpp
+++ b/src/scripts/src/QuestScripts/Quest_Hellfire_Peninsula.cpp
@@ -1,9 +1,8 @@
 /*
  * ArcScripts for ArcEmu MMORPG Server
- * Copyright (C) 2009 ArcEmu Team <http://www.arcemu.org/>
- * Copyright (C) 2008-2009 Sun++ Team <http://www.sunscripting.com/>
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2007-2008 Moon++ Team <http://www.moonplusplus.info/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2008-2009 Sun++ Team
+ * Copyright (C) 2007-2008 Moon++ Team 
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/scripts/src/QuestScripts/Quest_HillsbradFoothills.cpp
+++ b/src/scripts/src/QuestScripts/Quest_HillsbradFoothills.cpp
@@ -1,7 +1,7 @@
 /*
  * ArcScripts for ArcEmu MMORPG Server
- * Copyright (C) 2009 ArcEmu Team <http://www.arcemu.org/>
- * Copyright (C) 2008-2009 Sun++ Team <http://www.sunscripting.com/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2008-2009 Sun++ Team
  * Copyright (C) 2008 WEmu Team
  *
  * This program is free software: you can redistribute it and/or modify

--- a/src/scripts/src/QuestScripts/Quest_Howling_Fjord.cpp
+++ b/src/scripts/src/QuestScripts/Quest_Howling_Fjord.cpp
@@ -1,7 +1,7 @@
 /*
  * ArcScripts for ArcEmu MMORPG Server
- * Copyright (C) 2009 ArcEmu Team <http://www.arcemu.org/>
- * Copyright (C) 2008-2009 Sun++ Team <http://www.sunscripting.com/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2008-2009 Sun++ Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/scripts/src/QuestScripts/Quest_Isle_of_QuelDanas.cpp
+++ b/src/scripts/src/QuestScripts/Quest_Isle_of_QuelDanas.cpp
@@ -1,7 +1,7 @@
 /*
  * ArcScripts for ArcEmu MMORPG Server
- * Copyright (C) 2009-2010 ArcEmu Team <http://www.arcemu.org/>
- * Copyright (C) 2008-2009 Sun++ Team <http://www.sunscripting.com/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2008-2009 Sun++ Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/scripts/src/QuestScripts/Quest_LochModan.cpp
+++ b/src/scripts/src/QuestScripts/Quest_LochModan.cpp
@@ -1,7 +1,7 @@
 /*
  * ArcScripts for ArcEmu MMORPG Server
- * Copyright (C) 2009 ArcEmu Team <http://www.arcemu.org/>
- * Copyright (C) 2008-2009 Sun++ Team <http://www.sunscripting.com/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2008-2009 Sun++ Team
  * Copyright (C) 2008 WEmu Team
  *
  * This program is free software: you can redistribute it and/or modify

--- a/src/scripts/src/QuestScripts/Quest_Mage.cpp
+++ b/src/scripts/src/QuestScripts/Quest_Mage.cpp
@@ -1,9 +1,8 @@
 /*
  * ArcScripts for ArcEmu MMORPG Server
- * Copyright (C) 2009 ArcEmu Team <http://www.arcemu.org/>
- * Copyright (C) 2008-2009 Sun++ Team <http://www.sunscripting.com/>
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2007-2008 Moon++ Team <http://www.moonplusplus.info/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2008-2009 Sun++ Team
+ * Copyright (C) 2007-2008 Moon++ Team 
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/scripts/src/QuestScripts/Quest_Mulgore.cpp
+++ b/src/scripts/src/QuestScripts/Quest_Mulgore.cpp
@@ -1,7 +1,7 @@
 /*
  * ArcScripts for ArcEmu MMORPG Server
- * Copyright (C) 2009 ArcEmu Team <http://www.arcemu.org/>
- * Copyright (C) 2008-2009 Sun++ Team <http://www.sunscripting.com/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2008-2009 Sun++ Team
  * Copyright (C) 2008 WEmu Team
  *
  * This program is free software: you can redistribute it and/or modify

--- a/src/scripts/src/QuestScripts/Quest_Nagrand.cpp
+++ b/src/scripts/src/QuestScripts/Quest_Nagrand.cpp
@@ -1,9 +1,8 @@
 /*
  * ArcScripts for ArcEmu MMORPG Server
- * Copyright (C) 2009 ArcEmu Team <http://www.arcemu.org/>
- * Copyright (C) 2008-2009 Sun++ Team <http://www.sunscripting.com/>
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2007-2008 Moon++ Team <http://www.moonplusplus.info/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2008-2009 Sun++ Team
+ * Copyright (C) 2007-2008 Moon++ Team 
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/scripts/src/QuestScripts/Quest_Netherstorm.cpp
+++ b/src/scripts/src/QuestScripts/Quest_Netherstorm.cpp
@@ -1,7 +1,7 @@
 /*
  * ArcScripts for ArcEmu MMORPG Server
- * Copyright (C) 2009 ArcEmu Team <http://www.arcemu.org/>
- * Copyright (C) 2008-2009 Sun++ Team <http://www.sunscripting.com/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2008-2009 Sun++ Team
  * Copyright (C) 2008 WEmu Team
  *
  * This program is free software: you can redistribute it and/or modify

--- a/src/scripts/src/QuestScripts/Quest_Paladin.cpp
+++ b/src/scripts/src/QuestScripts/Quest_Paladin.cpp
@@ -1,9 +1,8 @@
 /*
  * ArcScripts for ArcEmu MMORPG Server
- * Copyright (C) 2009 ArcEmu Team <http://www.arcemu.org/>
- * Copyright (C) 2008-2009 Sun++ Team <http://www.sunscripting.com/>
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2007-2008 Moon++ Team <http://www.moonplusplus.info/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2008-2009 Sun++ Team
+ * Copyright (C) 2007-2008 Moon++ Team 
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/scripts/src/QuestScripts/Quest_RedridgeMountains.cpp
+++ b/src/scripts/src/QuestScripts/Quest_RedridgeMountains.cpp
@@ -1,7 +1,7 @@
 /*
  * ArcScripts for ArcEmu MMORPG Server
- * Copyright (C) 2009 ArcEmu Team <http://www.arcemu.org/>
- * Copyright (C) 2008-2009 Sun++ Team <http://www.sunscripting.com/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2008-2009 Sun++ Team
  * Copyright (C) 2008 WEmu Team
  *
  * This program is free software: you can redistribute it and/or modify

--- a/src/scripts/src/QuestScripts/Quest_ShadowMoon.cpp
+++ b/src/scripts/src/QuestScripts/Quest_ShadowMoon.cpp
@@ -1,9 +1,8 @@
 /*
  * ArcScripts for ArcEmu MMORPG Server
- * Copyright (C) 2009 ArcEmu Team <http://www.arcemu.org/>
- * Copyright (C) 2008-2009 Sun++ Team <http://www.sunscripting.com/>
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2007-2008 Moon++ Team <http://www.moonplusplus.info/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2008-2009 Sun++ Team
+ * Copyright (C) 2007-2008 Moon++ Team 
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/scripts/src/QuestScripts/Quest_SholazarBasin.cpp
+++ b/src/scripts/src/QuestScripts/Quest_SholazarBasin.cpp
@@ -1,9 +1,8 @@
 /*
  * ArcScripts for ArcEmu MMORPG Server
- * Copyright (C) 2009 ArcEmu Team <http://www.arcemu.org/>
- * Copyright (C) 2008-2009 Sun++ Team <http://www.sunscripting.com/>
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2007-2008 Moon++ Team <http://www.moonplusplus.info/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2008-2009 Sun++ Team
+ * Copyright (C) 2007-2008 Moon++ Team 
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/scripts/src/QuestScripts/Quest_SilvermoonCity.cpp
+++ b/src/scripts/src/QuestScripts/Quest_SilvermoonCity.cpp
@@ -1,7 +1,7 @@
 /*
  * ArcScripts for ArcEmu MMORPG Server
- * Copyright (C) 2009 ArcEmu Team <http://www.arcemu.org/>
- * Copyright (C) 2008-2009 Sun++ Team <http://www.sunscripting.com/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2008-2009 Sun++ Team
  * Copyright (C) 2008 WEmu Team
  *
  * This program is free software: you can redistribute it and/or modify

--- a/src/scripts/src/QuestScripts/Quest_Silverpine_Forest.cpp
+++ b/src/scripts/src/QuestScripts/Quest_Silverpine_Forest.cpp
@@ -1,9 +1,8 @@
 /*
  * ArcScripts for ArcEmu MMORPG Server
- * Copyright (C) 2009 ArcEmu Team <http://www.arcemu.org/>
- * Copyright (C) 2008-2009 Sun++ Team <http://www.sunscripting.com/>
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2007-2008 Moon++ Team <http://www.moonplusplus.info/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2008-2009 Sun++ Team
+ * Copyright (C) 2007-2008 Moon++ Team 
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/scripts/src/QuestScripts/Quest_Stormwind.cpp
+++ b/src/scripts/src/QuestScripts/Quest_Stormwind.cpp
@@ -1,7 +1,7 @@
 /*
  * ArcScripts for ArcEmu MMORPG Server
- * Copyright (C) 2009 ArcEmu Team <http://www.arcemu.org/>
- * Copyright (C) 2008-2009 Sun++ Team <http://www.sunscripting.com/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2008-2009 Sun++ Team
  * Copyright (C) 2008 WEmu Team
  *
  * This program is free software: you can redistribute it and/or modify

--- a/src/scripts/src/QuestScripts/Quest_StranglethornVale.cpp
+++ b/src/scripts/src/QuestScripts/Quest_StranglethornVale.cpp
@@ -1,7 +1,7 @@
 /*
  * ArcScripts for ArcEmu MMORPG Server
- * Copyright (C) 2009 ArcEmu Team <http://www.arcemu.org/>
- * Copyright (C) 2008-2009 Sun++ Team <http://www.sunscripting.com/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2008-2009 Sun++ Team
  * Copyright (C) 2008 WEmu Team
  *
  * This program is free software: you can redistribute it and/or modify

--- a/src/scripts/src/QuestScripts/Quest_Tanaris.cpp
+++ b/src/scripts/src/QuestScripts/Quest_Tanaris.cpp
@@ -1,7 +1,7 @@
 /*
  * ArcScripts for ArcEmu MMORPG Server
- * Copyright (C) 2009 ArcEmu Team <http://www.arcemu.org/>
- * Copyright (C) 2008-2009 Sun++ Team <http://www.sunscripting.com/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2008-2009 Sun++ Team
  * Copyright (C) 2008 WEmu Team
  *
  * This program is free software: you can redistribute it and/or modify

--- a/src/scripts/src/QuestScripts/Quest_Teldrassil.cpp
+++ b/src/scripts/src/QuestScripts/Quest_Teldrassil.cpp
@@ -1,7 +1,7 @@
 /*
  * ArcScripts for ArcEmu MMORPG Server
- * Copyright (C) 2009 ArcEmu Team <http://www.arcemu.org/>
- * Copyright (C) 2008-2009 Sun++ Team <http://www.sunscripting.com/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2008-2009 Sun++ Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/scripts/src/QuestScripts/Quest_Terrokar_Forest.cpp
+++ b/src/scripts/src/QuestScripts/Quest_Terrokar_Forest.cpp
@@ -1,9 +1,8 @@
 /*
  * ArcScripts for ArcEmu MMORPG Server
- * Copyright (C) 2009 ArcEmu Team <http://www.arcemu.org/>
- * Copyright (C) 2008-2009 Sun++ Team <http://www.sunscripting.com/>
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2007-2008 Moon++ Team <http://www.moonplusplus.info/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2008-2009 Sun++ Team
+ * Copyright (C) 2007-2008 Moon++ Team 
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/scripts/src/QuestScripts/Quest_TheStormPeaks.cpp
+++ b/src/scripts/src/QuestScripts/Quest_TheStormPeaks.cpp
@@ -1,6 +1,6 @@
 /*
  * ArcScripts for ArcEmu MMORPG Server
- * Copyright (C) 2009 ArcEmu Team <http://www.arcemu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/scripts/src/QuestScripts/Quest_The_Barrens.cpp
+++ b/src/scripts/src/QuestScripts/Quest_The_Barrens.cpp
@@ -1,9 +1,8 @@
 /*
  * ArcScripts for ArcEmu MMORPG Server
- * Copyright (C) 2009 ArcEmu Team <http://www.arcemu.org/>
- * Copyright (C) 2008-2009 Sun++ Team <http://www.sunscripting.com/>
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2007-2008 Moon++ Team <http://www.moonplusplus.info/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2008-2009 Sun++ Team
+ * Copyright (C) 2007-2008 Moon++ Team 
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/scripts/src/QuestScripts/Quest_ThousandNeedles.cpp
+++ b/src/scripts/src/QuestScripts/Quest_ThousandNeedles.cpp
@@ -1,7 +1,7 @@
 /*
  * ArcScripts for ArcEmu MMORPG Server
- * Copyright (C) 2009 ArcEmu Team <http://www.arcemu.org/>
- * Copyright (C) 2008-2009 Sun++ Team <http://www.sunscripting.com/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2008-2009 Sun++ Team
  * Copyright (C) 2008 WEmu Team
  *
  * This program is free software: you can redistribute it and/or modify

--- a/src/scripts/src/QuestScripts/Quest_TirisfalGlades.cpp
+++ b/src/scripts/src/QuestScripts/Quest_TirisfalGlades.cpp
@@ -1,7 +1,7 @@
 /*
  * ArcScripts for ArcEmu MMORPG Server
- * Copyright (C) 2009 ArcEmu Team <http://www.arcemu.org/>
- * Copyright (C) 2008-2009 Sun++ Team <http://www.sunscripting.com/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2008-2009 Sun++ Team
  * Copyright (C) 2008 WEmu Team
  *
  * This program is free software: you can redistribute it and/or modify

--- a/src/scripts/src/QuestScripts/Quest_UnGoro.cpp
+++ b/src/scripts/src/QuestScripts/Quest_UnGoro.cpp
@@ -1,9 +1,8 @@
 /*
  * ArcScripts for ArcEmu MMORPG Server
- * Copyright (C) 2009 ArcEmu Team <http://www.arcemu.org/>
- * Copyright (C) 2008-2009 Sun++ Team <http://www.sunscripting.com/>
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2007-2008 Moon++ Team <http://www.moonplusplus.info/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2008-2009 Sun++ Team
+ * Copyright (C) 2007-2008 Moon++ Team 
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/scripts/src/QuestScripts/Quest_Undercity.cpp
+++ b/src/scripts/src/QuestScripts/Quest_Undercity.cpp
@@ -1,9 +1,8 @@
 /*
  * ArcScripts for ArcEmu MMORPG Server
- * Copyright (C) 2009 ArcEmu Team <http://www.arcemu.org/>
- * Copyright (C) 2008-2009 Sun++ Team <http://www.sunscripting.com/>
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2007-2008 Moon++ Team <http://www.moonplusplus.info/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2008-2009 Sun++ Team
+ * Copyright (C) 2007-2008 Moon++ Team 
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/scripts/src/QuestScripts/Quest_Warrior.cpp
+++ b/src/scripts/src/QuestScripts/Quest_Warrior.cpp
@@ -1,7 +1,7 @@
 /*
  * ArcScripts for ArcEmu MMORPG Server
- * Copyright (C) 2009 ArcEmu Team <http://www.arcemu.org/>
- * Copyright (C) 2008-2009 Sun++ Team <http://www.sunscripting.com/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2008-2009 Sun++ Team
  * Copyright (C) 2008 WEmu Team
  *
  * This program is free software: you can redistribute it and/or modify

--- a/src/scripts/src/QuestScripts/Quest_Westfall.cpp
+++ b/src/scripts/src/QuestScripts/Quest_Westfall.cpp
@@ -1,7 +1,7 @@
 /*
  * ArcScripts for ArcEmu MMORPG Server
- * Copyright (C) 2009 ArcEmu Team <http://www.arcemu.org/>
- * Copyright (C) 2008-2009 Sun++ Team <http://www.sunscripting.com/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2008-2009 Sun++ Team
  * Copyright (C) 2008 WEmu Team
  *
  * This program is free software: you can redistribute it and/or modify

--- a/src/scripts/src/QuestScripts/Quest_Winterspring.cpp
+++ b/src/scripts/src/QuestScripts/Quest_Winterspring.cpp
@@ -1,5 +1,5 @@
 /*
- * Why Scripts for Arcemu MMORPG Server <http://www.arcemu.org/>
+ * Why Scripts for ArcEmu MMORPG Server 
  * Copyright (C) 2009 WhyScripts Team <http://www.whydb.org/>
  *
  * This program is free software: you can redistribute it and/or modify

--- a/src/scripts/src/QuestScripts/Quest_Zangarmarsh.cpp
+++ b/src/scripts/src/QuestScripts/Quest_Zangarmarsh.cpp
@@ -1,9 +1,8 @@
 /*
  * ArcScripts for ArcEmu MMORPG Server
- * Copyright (C) 2009 ArcEmu Team <http://www.arcemu.org/>
- * Copyright (C) 2008-2009 Sun++ Team <http://www.sunscripting.com/>
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2007-2008 Moon++ Team <http://www.moonplusplus.info/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2008-2009 Sun++ Team
+ * Copyright (C) 2007-2008 Moon++ Team 
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/scripts/src/QuestScripts/Setup.cpp
+++ b/src/scripts/src/QuestScripts/Setup.cpp
@@ -1,6 +1,6 @@
 /*
  * ArcScripts for ArcEmu MMORPG Server
- * Copyright (C) 2009 ArcEmu Team <http://www.arcemu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/scripts/src/QuestScripts/Setup.h
+++ b/src/scripts/src/QuestScripts/Setup.h
@@ -1,6 +1,6 @@
 /*
  * ArcScripts for ArcEmu MMORPG Server
- * Copyright (C) 2009 ArcEmu Team <http://www.arcemu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/scripts/src/QuestScripts/Unsorted.cpp
+++ b/src/scripts/src/QuestScripts/Unsorted.cpp
@@ -1,8 +1,8 @@
 
 /*
  * ArcScripts for ArcEmu MMORPG Server
- * Copyright (C) 2009 ArcEmu Team <http://www.arcemu.org/>
- * Copyright (C) 2008-2009 Sun++ Team <http://www.sunscripting.com/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2008-2009 Sun++ Team
  * Copyright (C) 2008 WEmu Team
  *
  * This program is free software: you can redistribute it and/or modify

--- a/src/scripts/src/ServerStatusPlugin/ServerStatusPlugin.cpp
+++ b/src/scripts/src/ServerStatusPlugin/ServerStatusPlugin.cpp
@@ -1,7 +1,7 @@
 /*
  * ArcScript Scripts for ArcEmu MMORPG Server
- * Copyright (C) 2008-2011 Arcemu Team <http://arcemu.org/>
- * Copyright (C) 2007 Moon++ <http://www.moonplusplus.com/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2007 Moon++
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/scripts/src/SpellHandlers/DeathKnightSpells.cpp
+++ b/src/scripts/src/SpellHandlers/DeathKnightSpells.cpp
@@ -1,7 +1,7 @@
 /*
- * ArcScript Scripts for Arcemu MMORPG Server
- * Copyright (C) 2008-2011 Arcemu Team
- * Copyright (C) 2007 Moon++ <http://www.moonplusplus.com/>
+ * ArcScript Scripts for ArcEmu MMORPG Server
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2007 Moon++
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/scripts/src/SpellHandlers/DruidSpells.cpp
+++ b/src/scripts/src/SpellHandlers/DruidSpells.cpp
@@ -1,7 +1,7 @@
 /*
- * ArcScript Scripts for Arcemu MMORPG Server
- * Copyright (C) 2008-2011 Arcemu Team
- * Copyright (C) 2007 Moon++ <http://www.moonplusplus.com/>
+ * ArcScript Scripts for ArcEmu MMORPG Server
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2007 Moon++
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/scripts/src/SpellHandlers/HunterSpells.cpp
+++ b/src/scripts/src/SpellHandlers/HunterSpells.cpp
@@ -1,7 +1,7 @@
 /*
- * ArcScript Scripts for Arcemu MMORPG Server
- * Copyright (C) 2008-2011 Arcemu Team
- * Copyright (C) 2007 Moon++ <http://www.moonplusplus.com/>
+ * ArcScript Scripts for ArcEmu MMORPG Server
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2007 Moon++
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/scripts/src/SpellHandlers/MageSpells.cpp
+++ b/src/scripts/src/SpellHandlers/MageSpells.cpp
@@ -1,7 +1,7 @@
 /*
- * ArcScript Scripts for Arcemu MMORPG Server
- * Copyright (C) 2008-2011 Arcemu Team
- * Copyright (C) 2007 Moon++ <http://www.moonplusplus.com/>
+ * ArcScript Scripts for ArcEmu MMORPG Server
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2007 Moon++
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/scripts/src/SpellHandlers/MiscSpells.cpp
+++ b/src/scripts/src/SpellHandlers/MiscSpells.cpp
@@ -1,7 +1,6 @@
 /*
  * ArcEmu MMORPG Server
- * Copyright (C) 2005-2007 Ascent Team <http://www.ascentemu.com/>
- * Copyright (C) 2008-2011 <http://www.ArcEmu.org/>
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/scripts/src/SpellHandlers/PaladinSpells.cpp
+++ b/src/scripts/src/SpellHandlers/PaladinSpells.cpp
@@ -1,7 +1,7 @@
 /*
- * ArcScript Scripts for Arcemu MMORPG Server
- * Copyright (C) 2008-2011 Arcemu Team
- * Copyright (C) 2007 Moon++ <http://www.moonplusplus.com/>
+ * ArcScript Scripts for ArcEmu MMORPG Server
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2007 Moon++
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/scripts/src/SpellHandlers/PriestSpells.cpp
+++ b/src/scripts/src/SpellHandlers/PriestSpells.cpp
@@ -1,7 +1,7 @@
 /*
- * ArcScript Scripts for Arcemu MMORPG Server
- * Copyright (C) 2008-2011 Arcemu Team
- * Copyright (C) 2007 Moon++ <http://www.moonplusplus.com/>
+ * ArcScript Scripts for ArcEmu MMORPG Server
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2007 Moon++
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/scripts/src/SpellHandlers/QIspells.cpp
+++ b/src/scripts/src/SpellHandlers/QIspells.cpp
@@ -1,6 +1,6 @@
 /*
- * ArcScript Scripts for Arcemu MMORPG Server
- * Copyright (C) 2008-2011 Arcemu Team
+ * ArcScript Scripts for ArcEmu MMORPG Server
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
  * Copyright (C) 2008 WEmu Team
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/scripts/src/SpellHandlers/RogueSpells.cpp
+++ b/src/scripts/src/SpellHandlers/RogueSpells.cpp
@@ -1,7 +1,7 @@
 /*
-* ArcScript Scripts for Arcemu MMORPG Server
-* Copyright (C) 2008-2011 Arcemu Team
-* Copyright (C) 2007 Moon++ <http://www.moonplusplus.com/>
+* ArcScript Scripts for ArcEmu MMORPG Server
+*  * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/> 
+* Copyright (C) 2007 Moon++
 *
 * This program is free software: you can redistribute it and/or modify
 * it under the terms of the GNU General Public License as published by

--- a/src/scripts/src/SpellHandlers/ShamanSpells.cpp
+++ b/src/scripts/src/SpellHandlers/ShamanSpells.cpp
@@ -1,7 +1,7 @@
 /*
- * ArcScript Scripts for Arcemu MMORPG Server
- * Copyright (C) 2008-2011 Arcemu Team
- * Copyright (C) 2007 Moon++ <http://www.moonplusplus.com/>
+ * ArcScript Scripts for ArcEmu MMORPG Server
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2007 Moon++
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/scripts/src/SpellHandlers/WarlockSpells.cpp
+++ b/src/scripts/src/SpellHandlers/WarlockSpells.cpp
@@ -1,7 +1,7 @@
 /*
- * ArcScript Scripts for Arcemu MMORPG Server
- * Copyright (C) 2008-2011 Arcemu Team
- * Copyright (C) 2007 Moon++ <http://www.moonplusplus.com/>
+ * ArcScript Scripts for ArcEmu MMORPG Server
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2007 Moon++
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/scripts/src/SpellHandlers/WarriorSpells.cpp
+++ b/src/scripts/src/SpellHandlers/WarriorSpells.cpp
@@ -1,7 +1,7 @@
 /*
- * ArcScript Scripts for Arcemu MMORPG Server
- * Copyright (C) 2008-2011 Arcemu Team
- * Copyright (C) 2007 Moon++ <http://www.moonplusplus.com/>
+ * ArcScript Scripts for ArcEmu MMORPG Server
+ * Copyright (C) 2008-2012 ArcEmu Team <http://arcemu.org/>
+ * Copyright (C) 2007 Moon++
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
Updating copyright headers to recent date, old projects with URLs that are now vacant or nonexistant have been removed.
