### PR TITLE
EventPeriodicTriggerSpell is now taking additional parameter to set a caster of spell.

### DIFF
--- a/src/arcemu-world/Spell.h
+++ b/src/arcemu-world/Spell.h
@@ -2234,6 +2234,7 @@ class SERVER_DECL Spell : public EventableObject
 		void AddChainTargets(uint32 i, uint32 TargetType, float r, uint32 maxtargets);
 		void AddConeTargets(uint32 i, uint32 TargetType, float r, uint32 maxtargets);
 		void AddScriptedOrSpellFocusTargets(uint32 i, uint32 TargetType, float r, uint32 maxtargets);
+		void RemoveTarget(uint32 i, Object* obj);
 
 	public:
 		SpellEntry* m_spellInfo;

--- a/src/arcemu-world/SpellAuras.cpp
+++ b/src/arcemu-world/SpellAuras.cpp
@@ -3051,7 +3051,7 @@ void Aura::SpellAuraPeriodicTriggerSpellWithValue(bool apply)
 				amptitude *= caster->GetCastSpeedMod();
 		}
 
-		sEventMgr.AddEvent(this, &Aura::EventPeriodicTriggerSpell, spe, true, mod->m_amount,
+		sEventMgr.AddEvent(this, &Aura::EventPeriodicTriggerSpell, spe, true, mod->m_amount, m_target,
 		                   EVENT_AURA_PERIODIC_TRIGGERSPELL, float2int32(amptitude), numticks, EVENT_FLAG_DO_NOT_EXECUTE_IN_WORLD_CONTEXT);
 	}
 }
@@ -3094,25 +3094,30 @@ void Aura::SpellAuraPeriodicTriggerSpell(bool apply)
 			return;
 
 
-		float amptitude = static_cast<float>(GetSpellProto()->EffectAmplitude[mod->i]);
-		Unit* caster = GetUnitCaster();
-		uint32 numticks = GetSpellDuration(m_spellProto, caster) / m_spellProto->EffectAmplitude[mod->i];
-		if(caster != NULL)
+		float amptitude = static_cast< float >(GetSpellProto()->EffectAmplitude[mod->i]);
+		Unit* u_caster = GetUnitCaster();
+		uint32 numticks = GetSpellDuration(m_spellProto, u_caster) / m_spellProto->EffectAmplitude[mod->i];
+		if(u_caster != NULL)
 		{
-			SM_FFValue(caster->SM_FAmptitude, &amptitude, m_spellProto->SpellGroupType);
-			SM_PFValue(caster->SM_PAmptitude, &amptitude, m_spellProto->SpellGroupType);
+			SM_FFValue(u_caster->SM_FAmptitude, &amptitude, m_spellProto->SpellGroupType);
+			SM_PFValue(u_caster->SM_PAmptitude, &amptitude, m_spellProto->SpellGroupType);
 			if(m_spellProto->ChannelInterruptFlags != 0)
-				amptitude *= caster->GetCastSpeedMod();
+				amptitude *= u_caster->GetCastSpeedMod();
 		}
 
-		sEventMgr.AddEvent(this, &Aura::EventPeriodicTriggerSpell, trigger, false, int32(0),
-		                   EVENT_AURA_PERIODIC_TRIGGERSPELL, float2int32(amptitude), numticks, EVENT_FLAG_DO_NOT_EXECUTE_IN_WORLD_CONTEXT);
+		if(trigger->EffectImplicitTargetA[0] == 76)
+			sEventMgr.AddEvent(this, &Aura::EventPeriodicTriggerSpell, trigger, false, int32(0), u_caster,
+		                   EVENT_AURA_PERIODIC_TRIGGERSPELL, static_cast< int32 >(amptitude), numticks, EVENT_FLAG_DO_NOT_EXECUTE_IN_WORLD_CONTEXT);
+		else
+			sEventMgr.AddEvent(this, &Aura::EventPeriodicTriggerSpell, trigger, false, int32(0), m_target,
+		                   EVENT_AURA_PERIODIC_TRIGGERSPELL, static_cast< int32 >(amptitude), numticks, EVENT_FLAG_DO_NOT_EXECUTE_IN_WORLD_CONTEXT);
+
 	}
 }
 
-void Aura::EventPeriodicTriggerSpell(SpellEntry* spellInfo, bool overridevalues, int32 overridevalue)
+void Aura::EventPeriodicTriggerSpell(SpellEntry* spellInfo, bool overridevalues, int32 overridevalue, Unit* caster)
 {
-	Spell* spell = sSpellFactoryMgr.NewSpell(m_target, spellInfo, true, this);
+	Spell* spell = sSpellFactoryMgr.NewSpell(caster, spellInfo, true, this);
 	if(overridevalues)
 	{
 		spell->m_overrideBasePoints = true;

--- a/src/arcemu-world/SpellAuras.h
+++ b/src/arcemu-world/SpellAuras.h
@@ -776,7 +776,7 @@ class SERVER_DECL Aura : public EventableObject
 		void EventPeriodicDamage(uint32);
 		void EventPeriodicDamagePercent(uint32);
 		void EventPeriodicHeal(uint32);
-		void EventPeriodicTriggerSpell(SpellEntry* spellInfo, bool overridevalues, int32 overridevalue);
+		void EventPeriodicTriggerSpell(SpellEntry* spellInfo, bool overridevalues, int32 overridevalue, Unit* caster);
 		void EventPeriodicTrigger(uint32 amount, uint32 type);
 		void EventPeriodicEnergize(uint32, uint32);
 		void EventPeriodicEnergizeVariable(uint32, uint32);

--- a/src/arcemu-world/SpellTarget.cpp
+++ b/src/arcemu-world/SpellTarget.cpp
@@ -165,6 +165,13 @@ void Spell::FillTargetMap(uint32 i)
 
 	if(TargetType & SPELL_TARGET_OBJECT_SCRIPTED)
 		AddScriptedOrSpellFocusTargets(i, TargetType, GetRadius(i), m_spellInfo->MaxTargets);
+
+	//Mind Sear aura target removal
+	if(GetProto()->Id == 53022 || GetProto()->Id == 49821)
+	{
+		Object* target = m_caster->GetMapMgr()->_GetObject(m_caster->GetUInt64Value(UNIT_FIELD_CHANNEL_OBJECT));
+		RemoveTarget(i, target);
+	}
 }
 
 void Spell::AddScriptedOrSpellFocusTargets(uint32 i, uint32 TargetType, float r, uint32 maxtargets)
@@ -384,6 +391,17 @@ void Spell::AddAOETargets(uint32 i, uint32 TargetType, float r, uint32 maxtarget
 		if(dist <= r)
 			AddTarget(i, TargetType, (*itr));
 	}
+}
+
+void Spell::RemoveTarget(uint32 i, Object* obj)
+{
+	TargetsList* t = &m_targetUnits[i];
+
+	if(obj == NULL || !obj->IsInWorld())
+		return;
+
+	t->erase(std::remove(t->begin(), t->end(), obj->GetGUID()), t->end());
+
 }
 
 bool Spell::AddTarget(uint32 i, uint32 TargetType, Object* obj)


### PR DESCRIPTION
EventPeriodicTriggerSpell is now taking additional parameter to set who will be an owner of triggered spell, original caster or the one who has aura. Fixes issues with Mind Sear and other spells that have implicit target value 76.

Basicaly same as my Mind Sear pull request but in less hacky way and affects much more spells that just 2.
