### PR TITLE
fix for the quest Leyline id: 11547

### DIFF
--- a/src/scripts/src/SpellHandlers/QIspells.cpp
+++ b/src/scripts/src/SpellHandlers/QIspells.cpp
@@ -2763,7 +2763,7 @@ bool LeyLine(uint32 i, Spell* pSpell)
 	if(qle == NULL)
 		return true;
 
-	uint32 portals[] = { 188527, 188526, 188525 };
+	uint32 portals[] = { 300155, 300156, 300154 };
 	Object* portal = NULL;
 
 	for(uint32 i = 0; i < sizeof(portals) / sizeof(uint32); i++)


### PR DESCRIPTION
This is a fix for the quest Leyline corrected goids that you can complete the quest
jump to : .worldport 530 12776.90 -6702.14 1.33 add quest 11547 and use the questitem. Dont counts because infalid gameobject ids
