### PR TITLE
Implemented Spell Aura 231 (Icy Talons, Blood Worms and other spells)

### DIFF
--- a/src/arcemu-world/SpellAuras.cpp
+++ b/src/arcemu-world/SpellAuras.cpp
@@ -253,7 +253,7 @@ pSpellAura SpellAuraHandler[TOTAL_SPELL_AURAS] =
 	&Aura::SpellAuraModStealthDetection,//228 Stealth Detection. http://www.thottbot.com/s34709
 	&Aura::SpellAuraReduceAOEDamageTaken,//229 Apply Aura:Reduces the damage your pet takes from area of effect attacks http://www.thottbot.com/s35694
 	&Aura::SpellAuraIncreaseMaxHealth,//230 Increase Max Health (commanding shout);
-	&Aura::SpellAuraNULL,//231 curse a target http://www.thottbot.com/s40303
+	&Aura::SpellAuraProcTriggerSpellWithValue,//231 curse a target http://www.thottbot.com/s40303
 	&Aura::SpellAuraReduceEffectDuration,//232 // Reduces duration of Magic effects by $s2%. SPELL_AURA_MECHANIC_DURATION_MOD
 	&Aura::SpellAuraNULL,//233 // Beer Goggles
 	&Aura::SpellAuraReduceEffectDuration,//234 Apply Aura: Reduces Silence or Interrupt effects, Item spell magic http://www.thottbot.com/s42184
@@ -575,7 +575,7 @@ const char* SpellAuraNames[TOTAL_SPELL_AURAS] =
 	"",													// 228
 	"SPELL_AURA_REDUCE_AOE_DAMAGE_TAKEN",				// 229
 	"INCREASE_MAX_HEALTH",								// 230 Used by Commanding Shout
-	"",													// 231
+	"SPELL_AURA_PROC_TRIGGER_SPELL_WITH_VALUE",			// 231
 	"SPELL_AURA_MECHANIC_DURATION_MOD",					// 232
 	"",													// 233
 	"",													// 234
@@ -4043,6 +4043,57 @@ void Aura::SpellAuraProcTriggerSpell(bool apply)
 		m_target->AddProcTriggerSpell(spellId, GetSpellProto()->Id, m_casterGuid, GetSpellProto()->procChance, GetSpellProto()->procFlags, charges, groupRelation, NULL);
 
 		LOG_DEBUG("%u is registering %u chance %u flags %u charges %u triggeronself %u interval %u", GetSpellProto()->Id, spellId, GetSpellProto()->procChance, GetSpellProto()->procFlags & ~PROC_TARGET_SELF, charges, GetSpellProto()->procFlags & PROC_TARGET_SELF, GetSpellProto()->proc_interval);
+	}
+	else
+	{
+		// Find spell of effect to be triggered
+		uint32 spellId = GetSpellProto()->EffectTriggerSpell[mod->i];
+		if(spellId == 0)
+		{
+			LOG_DEBUG("Warning! trigger spell is null for spell %u", GetSpellProto()->Id);
+			return;
+		}
+
+		m_target->RemoveProcTriggerSpell(spellId, m_casterGuid);
+	}
+}
+
+void Aura::SpellAuraProcTriggerSpellWithValue(bool apply)
+{
+	if(apply)
+	{
+		uint32 groupRelation[3];
+		int charges;
+		uint32 spellId;
+
+		// Find spell of effect to be triggered
+		spellId = GetSpellProto()->EffectTriggerSpell[mod->i];
+		if(spellId == 0)
+		{
+			LOG_DEBUG("Warning! trigger spell is null for spell %u", GetSpellProto()->Id);
+			return;
+		}
+
+		// Initialize mask
+		groupRelation[0] = GetSpellProto()->EffectSpellClassMask[mod->i][0];
+		groupRelation[1] = GetSpellProto()->EffectSpellClassMask[mod->i][1];
+		groupRelation[2] = GetSpellProto()->EffectSpellClassMask[mod->i][2];
+
+		// Initialize charges
+		charges = GetSpellProto()->procCharges;
+		Unit* ucaster = GetUnitCaster();
+		if(ucaster != NULL && GetSpellProto()->SpellGroupType)
+		{
+			SM_FIValue(ucaster->SM_FCharges, &charges, GetSpellProto()->SpellGroupType);
+			SM_PIValue(ucaster->SM_PCharges, &charges, GetSpellProto()->SpellGroupType);
+		}
+
+		SpellEntry* spellInfo = dbcSpell.LookupEntry(spellId);
+		spellInfo->EffectBasePoints[0] = mod->m_amount;
+
+		m_target->AddProcTriggerSpell(spellInfo->Id, GetSpellProto()->Id, m_casterGuid, GetSpellProto()->procChance, GetSpellProto()->procFlags, charges, groupRelation, NULL);
+
+		LOG_DEBUG("%u is registering %u chance %u flags %u charges %u trigger on self %u interval %u", GetSpellProto()->Id, spellId, GetSpellProto()->procChance, GetSpellProto()->procFlags & ~PROC_TARGET_SELF, charges, GetSpellProto()->procFlags & PROC_TARGET_SELF, GetSpellProto()->proc_interval);
 	}
 	else
 	{

--- a/src/arcemu-world/SpellAuras.h
+++ b/src/arcemu-world/SpellAuras.h
@@ -274,6 +274,7 @@ enum MOD_TYPES
     SPELL_AURA_PERIODIC_TRIGGER_SPELL_WITH_VALUE = 227, // Used by Mind Flay etc
     SPELL_AURA_REDUCE_AOE_DAMAGE_TAKEN = 229,
     SPELL_AURA_INCREASE_MAX_HEALTH = 230, //Used by Commanding Shout
+	SPELL_AURA_PROC_TRIGGER_SPELL_WITH_VALUE = 231,
     SPELL_AURA_MECHANIC_DURATION_MOD = 232,
     SPELL_AURA_MOD_HEALING_BY_AP = 237,
     SPELL_AURA_MOD_SPELL_DAMAGE_BY_AP = 238,
@@ -585,6 +586,7 @@ class SERVER_DECL Aura : public EventableObject
 		void SpellAuraModDmgImmunity(bool apply);
 		void SpellAuraModDispelImmunity(bool apply);
 		void SpellAuraProcTriggerSpell(bool apply);
+		void SpellAuraProcTriggerSpellWithValue(bool apply);
 		void SpellAuraProcTriggerDamage(bool apply);
 		void SpellAuraTrackCreatures(bool apply);
 		void SpellAuraTrackResources(bool apply);

--- a/src/arcemu-world/Unit.cpp
+++ b/src/arcemu-world/Unit.cpp
@@ -1168,23 +1168,6 @@ uint32 Unit::HandleProc(uint32 flag, Unit* victim, SpellEntry* CastingSpell, boo
 			uint32 talentlevel = 0;
 			switch(origId)
 			{
-					//mace specialization
-				case 12284:
-					{talentlevel = 1;}
-					break;
-				case 12701:
-					{talentlevel = 2;}
-					break;
-				case 12702:
-					{talentlevel = 3;}
-					break;
-				case 12703:
-					{talentlevel = 4;}
-					break;
-				case 12704:
-					{talentlevel = 5;}
-					break;
-
 					//Unbridled Wrath
 				case 12999:
 					{talentlevel = 1;}


### PR DESCRIPTION
Subj, but need your suggestions on how to do it better, I can make it to be handled in Aura::SpellAuraProcTriggerSpell and just make a check for GetSpellProto()->EffectApplyAuraName[i] == SPELL_AURA_PROC_TRIGGER_SPELL_WITH_VALUE to modify its value, because code was just copypasted from there, so I will avoid of having exactly same code in two places...

Also I have another idea, but that would require to touch SpellProc manager and many other places to modify value of triggered spell... just need your suggestions on which way is better.

Here what exactly been changed in comparison to copypasted code from Aura::SpellAuraProcTriggerSpell:
https://gist.github.com/3347357
