### PR TITLE
Fix for Arena ending.

### DIFF
--- a/src/arcemu-world/Arenas.cpp
+++ b/src/arcemu-world/Arenas.cpp
@@ -295,7 +295,7 @@ void Arena::UpdatePlayerCounts()
 	if(!m_started)
 		return;
 
-	return;
+//	return;
 
 	if(m_playersCount[1] == 0)
 		m_winningteam = 0;


### PR DESCRIPTION
Fix bug : https://github.com/arcemu/arcemu/issues/141

This return made Arena matches not ending when a team was completely killed.
Removing this return actually makes skirmish arenas works fine. 
Still have to try rated arenas (but problem, if there is one, would come from the "Finish()" function).

How to reproduce: Simply queue for any type of arena and kill enemy. Won't end the game (nor show scores).
