### PR TITLE
Fixed a skirmish arena queue bug

### DIFF
--- a/src/arcemu-world/BattlegroundMgr.cpp
+++ b/src/arcemu-world/BattlegroundMgr.cpp
@@ -595,11 +595,12 @@ void CBattlegroundManager::EventQueueUpdate(bool forceStart)
 			if(IS_ARENA(i))
 			{
 				// enough players to start a round?
-				uint32 minPlayers = BattlegroundManager.GetMinimumPlayers(i);
+				uint32 minPlayers = BattlegroundManager.GetMinimumPlayers(i) * 2;
 				if(!forceStart && tempPlayerVec[0].size() < minPlayers)
 					continue;
 
-				if(CanCreateInstance(i, j))
+				// if(CanCreateInstance(i, j))
+				if(forceStart || tempPlayerVec[0].size() >= minPlayers)
 				{
 					arena = TO< Arena* >(CreateInstance(i, j));
 					if(arena == NULL)


### PR DESCRIPTION
Fixed a skirmish arena queue bug where the arena launched when you were only 2 in the queue (so 1v1).
Now works properly : it wait for four players to tag 2v2 (six to 3v3) before launching one(for rated too).
It didn't affect rated because queue was only in a full group, so there were never only 2 people in the queue.
