### PR TITLE
Fixes Issue #198 Innkeeper doesn't sell hearthstone

### DIFF
--- a/src/arcemu-world/NPCHandler.cpp
+++ b/src/arcemu-world/NPCHandler.cpp
@@ -635,26 +635,6 @@ void WorldSession::SendInnkeeperBind(Creature* pCreature)
 	_player->bHasBindDialogOpen = false;
 	OutPacket(SMSG_GOSSIP_COMPLETE, 0, NULL);
 
-	// if the player has no hearthstone (item db entry 6948, count 0, check also bank)
-	if (_player->HasItemCount(6948,0,true))
-	{
-		// create new hearthstone
-		Item* item = objmgr.CreateItem(6948, _player);
-		// if the new hearthstone can't get added to the inventory, delete it
-		if(!_player->m_ItemInterface->AddItemToFreeSlot(item))
-			{
-				item->DeleteMe();
-				_player->GetItemInterface()->BuildInventoryChangeError(NULL, NULL, INV_ERR_BAG_FULL);
-				return;
-			}
-		// else add the new hearthstone to the inventory
-		else
-			_player->SendItemPushResult(false, true, false, true,
-				                   _player->m_ItemInterface->LastSearchItemBagSlot(), _player->m_ItemInterface->LastSearchItemSlot(),
-				                   1, item->GetEntry(), item->GetItemRandomSuffixFactor(), item->GetItemRandomPropertyId(), item->GetStackCount());
-	}
-
-	// makes this inn the new home of the player  
 	pCreature->CastSpell(_player->GetGUID(), BIND_SPELL_ID, true);
 }
 

--- a/src/arcemu-world/SpellEffects.cpp
+++ b/src/arcemu-world/SpellEffects.cpp
@@ -1595,6 +1595,21 @@ void Spell::SpellEffectCreateItem(uint32 i)
 		count += countforlevel;
 	}
 
+	// CreateItemEffect of the Spell Bind (Innkeepers)
+	if(spellid == 3286)
+	{
+		// If the Player has no Hearthstone, even bank slots are checked
+		if(playerTarget->HasItemCount(itemid,0,true))
+		{
+			count = 1;
+			playerTarget->GetItemInterface()->AddItemById(itemid, count, 0);
+		}
+		// If the Player already has a Hearthstone don't do anything here
+		else
+		{
+			return;
+		}
+	}
 
 	if(count <= 0)
 	{


### PR DESCRIPTION
If the player has no hearthstone (bank slots are also checked) the player gets a new one by an innkeeper when he wants to make the inn his home.
