### PR TITLE
Fix compile warning "initialized and declared 'extern'"

### DIFF
--- a/src/arcemu-world/AIEvents.cpp
+++ b/src/arcemu-world/AIEvents.cpp
@@ -20,7 +20,7 @@
 
 #include "StdAfx.h"
 
-extern pAIEvent AIEventHandlers[NUM_AI_EVENTS] =
+pAIEvent AIEventHandlers[NUM_AI_EVENTS] =
 {
 	&AIInterface::EventEnterCombat,
 	&AIInterface::EventLeaveCombat,


### PR DESCRIPTION
Really. It's defined external in the header, so in cpp its local.
