### PR TITLE
Fixed emote, msg type and renamed function for quest 'Report to Goldshire'

### DIFF
--- a/src/plugins/QuestScripts/QuestHooks.cpp
+++ b/src/plugins/QuestScripts/QuestHooks.cpp
@@ -78,12 +78,12 @@ void Rest_n_Relaxation(Player* pPlayer, Object* pObject)
 	(TO_CREATURE(pObject))->Emote(EMOTE_ONESHOT_CHEER);
 }
 
-void OntoGoldshireComplete(Player* pPlayer, Object* pObject)
+void ReportToGoldshire(Player* pPlayer, Object* pObject)
 {
 	char msg[256];
 	snprintf((char*)msg, 256, "You are dismissed %s . ", pPlayer->GetName());
-	(TO_CREATURE(pObject))->SendChatMessage(CHAT_MSG_MONSTER_YELL, LANG_UNIVERSAL, msg);
-	(TO_CREATURE(pObject))->Emote(EMOTE_ONESHOT_BOW);
+	(TO_CREATURE(pObject))->SendChatMessage(CHAT_MSG_MONSTER_SAY, LANG_UNIVERSAL, msg);
+	(TO_CREATURE(pObject))->Emote(EMOTE_ONESHOT_SALUTE_NOSHEATH);
 }
 
 void ZuluhedtheWhacked(Player* pPlayer, Object* pObject)
@@ -131,7 +131,7 @@ void OnQuestAccept(Player* pPlayer, Quest* pQuest, Object* pObject)
 			Rest_n_Relaxation(pPlayer, pObject);
 			break;
 		case 54:
-			OntoGoldshireComplete(pPlayer, pObject);
+			ReportToGoldshire(pPlayer, pObject);
 			break;
 		case 10872:
 			ZuluhedtheWhacked(pPlayer, pObject);


### PR DESCRIPTION
Also the emote part could be handle trought database on quest table. Im wondering if will better remove them from here.