### PR TITLE
Fixed wrong msg type for quest 'A Humble Task'.

### DIFF
--- a/src/plugins/QuestScripts/QuestHooks.cpp
+++ b/src/plugins/QuestScripts/QuestHooks.cpp
@@ -42,7 +42,7 @@ void Hanazua(Player* pPlayer, Object* pObject)
 
 void AHumbleTask(Player* pPlayer, Object* pObject)
 {
-	(TO_CREATURE(pObject))->SendChatMessage(CHAT_MSG_MONSTER_SAY, LANG_UNIVERSAL, "Greatmother Hawkwind gestures to the pitcher of water sitting on the edge of the well.");
+	(TO_CREATURE(pObject))->SendChatMessage(CHAT_MSG_MONSTER_EMOTE, LANG_UNIVERSAL, "Greatmother Hawkwind gestures to the pitcher of water sitting on the edge of the well.");
 }
 
 void Yorus_Barleybrew(Player* pPlayer, Object* pObject)


### PR DESCRIPTION
arcemu: d1627e5b179556c0f0b57e88bf783215bffc569b

Message type should be CHAT_MSG_MONSTER_EMOTE

.npc portto 24054