### PR TITLE
chore(git): ignore bin and Build folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 .vagrant
+
+bin/
+
+Build/


### PR DESCRIPTION
Tell Git to ignore the build generated bin/ and Build/ directories