### PR TITLE
Fix ParseTuple parameter size on ILP64

### DIFF
--- a/src/plugins/PythonEngine/python/modules/ArcPyCreature.cpp
+++ b/src/plugins/PythonEngine/python/modules/ArcPyCreature.cpp
@@ -98,7 +98,7 @@ static PyObject* ArcPyCreature_createCustomWaypoint( ArcPyCreature *self, PyObje
 	uint32 flags;
 	uint32 model;
 
-	if( !PyArg_ParseTuple( args, "ffffkkk", &x, &y, &z, &o, &wait, &flags, &model ) )
+    if( !PyArg_ParseTuple( args, "ffffIII", &x, &y, &z, &o, &wait, &flags, &model ) )
 	{
 		PyErr_SetString( PyExc_TypeError, "This method requires x,y,z,o,wait,flags,model parameters" );
 		return NULL;
@@ -159,7 +159,7 @@ static PyObject* ArcPyCreature_createCustomWaypoint( ArcPyCreature *self, PyObje
 static PyObject* ArcPyCreature_setMovementType( ArcPyCreature *self, PyObject *args )
 {
 	uint32 type;
-	if( !PyArg_ParseTuple( args, "k", &type ) )
+    if( !PyArg_ParseTuple( args, "I", &type ) )
 	{
 		PyErr_SetString( PyExc_TypeError, "This method requires a type parameter" );
 		return NULL;
@@ -207,7 +207,7 @@ static PyObject* ArcPyCreature_resetWaypoint( ArcPyCreature *self, PyObject *arg
 static PyObject* ArcPyCreature_setCanRegenerateHP( ArcPyCreature *self, PyObject *args )
 {
 	uint32 canRegenerate;
-	if( !PyArg_ParseTuple( args, "k", &canRegenerate ) )
+    if( !PyArg_ParseTuple( args, "I", &canRegenerate ) )
 	{
 		PyErr_SetString( PyExc_TypeError, "This method requires an integer parameter" );
 		return NULL;
@@ -238,7 +238,7 @@ static PyObject* ArcPyCreature_stopMovement( ArcPyCreature *self, PyObject *args
 {
 	uint32 time = 0;
 
-	if( !PyArg_ParseTuple( args, "k", &time ) )
+    if( !PyArg_ParseTuple( args, "I", &time ) )
 	{
 		PyErr_SetString( PyExc_TypeError, "This method requires a time parameter" );
 		return NULL;
@@ -268,7 +268,7 @@ static PyObject* ArcPyCreature_despawn( ArcPyCreature *self, PyObject *args )
 	uint32 delay;
 	uint32 respawnTime;
 
-	if( !PyArg_ParseTuple( args, "kk", &delay, &respawnTime ) )
+    if( !PyArg_ParseTuple( args, "II", &delay, &respawnTime ) )
 	{
 		PyErr_SetString( PyExc_TypeError, "This method requires a delay and a respawntime parameter" );
 		return NULL;
@@ -300,7 +300,7 @@ static PyObject* ArcPyCreature_addNpcFlag( ArcPyCreature *self, PyObject *args )
 {
 	uint32 flag;
 
-	if( !PyArg_ParseTuple( args, "k", &flag ) )
+    if( !PyArg_ParseTuple( args, "I", &flag ) )
 	{
 		PyErr_SetString( PyExc_TypeError, "This method requires a flag as a parameter" );
 		return NULL;
@@ -328,7 +328,7 @@ static PyObject* ArcPyCreature_removeNpcFlag( ArcPyCreature *self, PyObject *arg
 {
 	uint32 flag;
 
-	if( !PyArg_ParseTuple( args, "k", &flag ) )
+    if( !PyArg_ParseTuple( args, "I", &flag ) )
 	{
 		PyErr_SetString( PyExc_TypeError, "This method requires a flag as a parameter" );
 		return NULL;
@@ -357,7 +357,7 @@ static PyObject* ArcPyCreature_hasNpcFlag( ArcPyCreature *self, PyObject *args )
 {
 	uint32 flag;
 
-	if( !PyArg_ParseTuple( args, "k", &flag ) )
+    if( !PyArg_ParseTuple( args, "I", &flag ) )
 	{
 		PyErr_SetString( PyExc_TypeError, "This method requires a flag as a parameter" );
 		return NULL;
@@ -397,7 +397,7 @@ static PyObject* ArcPyCreature_addVendorItem( ArcPyCreature *self, PyObject *arg
 	uint32 amount = 1;
 	uint32 extendedCostId = 0;
 
-	if( !PyArg_ParseTuple( args, "k|kk", &id, &amount, &extendedCostId ) )
+    if( !PyArg_ParseTuple( args, "I|II", &id, &amount, &extendedCostId ) )
 	{
 		PyErr_SetString( PyExc_ValueError, "This method requires an item Id as parameter" );
 		return NULL;
@@ -439,7 +439,7 @@ static PyObject* ArcPyCreature_removeVendorItem( ArcPyCreature *self, PyObject *
 {
 	uint32 id;
 
-	if( !PyArg_ParseTuple( args, "k", &id ) )
+    if( !PyArg_ParseTuple( args, "I", &id ) )
 	{
 		PyErr_SetString( PyExc_ValueError, "This method requires an item Id as parameter" );
 		return NULL;

--- a/src/plugins/PythonEngine/python/modules/ArcPyGameObject.cpp
+++ b/src/plugins/PythonEngine/python/modules/ArcPyGameObject.cpp
@@ -101,7 +101,7 @@ static PyObject* ArcPyGameObject_RegisterAIUpdateEvent( ArcPyGameObject* self, P
 
 	uint32 interval;
 
-	if( !PyArg_ParseTuple( args, "k", &interval ) )
+    if( !PyArg_ParseTuple( args, "I", &interval ) )
 	{
 		PyErr_SetString( PyExc_ValueError, "This method requires an interval parameter" );
 		return NULL;
@@ -136,7 +136,7 @@ static PyObject* ArcPyGameObject_ModifyAIUpdateEvent( ArcPyGameObject* self, PyO
 
 	uint32 interval;
 
-	if( !PyArg_ParseTuple( args, "k", &interval ) )
+    if( !PyArg_ParseTuple( args, "I", &interval ) )
 	{
 		PyErr_SetString( PyExc_ValueError, "This method requires an interval parameter" );
 		return NULL;
@@ -186,7 +186,7 @@ static PyObject* ArcPyGameObject_despawn( ArcPyGameObject* self, PyObject* args 
 	uint32 delay;
 	uint32 respawnTime;
 
-	if( !PyArg_ParseTuple( args, "kk", &delay, &respawnTime ) )
+    if( !PyArg_ParseTuple( args, "II", &delay, &respawnTime ) )
 	{
 		PyErr_SetString( PyExc_ValueError, "This method requires a delay, and a respawn time parameter" );
 		return NULL;

--- a/src/plugins/PythonEngine/python/modules/ArcPyGossipMenu.cpp
+++ b/src/plugins/PythonEngine/python/modules/ArcPyGossipMenu.cpp
@@ -53,11 +53,11 @@ static PyObject* ArcPyGossipMenu_new( PyTypeObject *type, PyObject *args, PyObje
 ///
 static int ArcPyGossipMenu_init( ArcPyGossipMenu *self, PyObject *args, PyObject *keywords )
 {
-	unsigned long textId = 0;
+    uint32 textId = 0;
 	PyObject* obj = NULL;
-	unsigned long autoSend = 0;
+    uint32 autoSend = 0;
 
-	if( ! PyArg_ParseTuple( args, "kOk", &textId, &obj, &autoSend ) )
+    if( ! PyArg_ParseTuple( args, "IOI", &textId, &obj, &autoSend ) )
 	{
 		return -1;
 	}
@@ -104,17 +104,17 @@ static void ArcPyGossipMenu_dealloc( ArcPyGossipMenu* self )
 ///
 static PyObject* ArcPyGossipMenu_addItem( ArcPyGossipMenu *self, PyObject *args )
 {
-	unsigned long icon = 0;
+    uint32 icon = 0;
 	const char* text = NULL;
-	unsigned long optionId = 0;
-	unsigned long coded = 0;
+    uint32 optionId = 0;
+    uint32 coded = 0;
 
 	const char *boxMessage = "";
-	unsigned long boxMoney = 0;
+    uint32 boxMoney = 0;
 
 	ARCEMU_ASSERT( self->gossipMenuPtr != NULL );
 
-	if( ! PyArg_ParseTuple( args, "kskk|sk", &icon, &text, &optionId, &coded, &boxMessage, &boxMoney ) )
+    if( ! PyArg_ParseTuple( args, "IsII|sI", &icon, &text, &optionId, &coded, &boxMessage, &boxMoney ) )
 	{
 		return NULL;
 	}

--- a/src/plugins/PythonEngine/python/modules/ArcPyMapMgr.cpp
+++ b/src/plugins/PythonEngine/python/modules/ArcPyMapMgr.cpp
@@ -84,7 +84,7 @@ static PyObject* ArcPyMapMgr_spawnCreature( ArcPyMapMgr *self, PyObject *args )
 	float y;
 	float z;
 
-	if( !PyArg_ParseTuple( args, "kfff", &id, &x, &y, &z ) )
+    if( !PyArg_ParseTuple( args, "Ifff", &id, &x, &y, &z ) )
 	{
 		PyErr_SetString( PyExc_ValueError, "This method requires id,x,y,z parameters" );
 		return NULL;
@@ -131,7 +131,7 @@ static PyObject* ArcPyMapMgr_spawnGameObject( ArcPyMapMgr *self, PyObject *args 
 	float y;
 	float z;
 
-	if( !PyArg_ParseTuple( args, "kfff", &id, &x, &y, &z ) )
+    if( !PyArg_ParseTuple( args, "Ifff", &id, &x, &y, &z ) )
 	{
 		PyErr_SetString( PyExc_ValueError, "This method requires id,x,y,z parameters" );
 		return NULL;
@@ -236,7 +236,7 @@ static PyObject* ArcPyMapMgr_getWorldState( ArcPyMapMgr *self, PyObject *args )
 	uint32 zoneId;
 	uint32 field;
 
-	if( !PyArg_ParseTuple( args, "kk", &zoneId, &field ) )
+    if( !PyArg_ParseTuple( args, "II", &zoneId, &field ) )
 	{
 		PyErr_SetString( PyExc_ValueError, "This method requires zone, field parameters" );
 		return NULL;
@@ -270,7 +270,7 @@ static PyObject* ArcPyMapMgr_updateWorldState( ArcPyMapMgr *self, PyObject *args
 	uint32 field;
 	uint32 value;
 
-	if( !PyArg_ParseTuple( args, "kkk", &zoneId, &field, &value ) )
+    if( !PyArg_ParseTuple( args, "III", &zoneId, &field, &value ) )
 	{
 		PyErr_SetString( PyExc_ValueError, "This method requires zone, field, value parameters" );
 		return NULL;
@@ -307,7 +307,7 @@ static PyObject* ArcPyMapMgr_getCreatureNearestCoords( ArcPyMapMgr *self, PyObje
 	float z;
 	uint32 id;
 
-	if( !PyArg_ParseTuple( args, "fffk", &x, &y, &z, &id ) ) 
+    if( !PyArg_ParseTuple( args, "fffI", &x, &y, &z, &id ) )
 	{
 		PyErr_SetString( PyExc_ValueError, "This method requires x,y,z and entry parameters" );
 		return NULL;
@@ -349,7 +349,7 @@ static PyObject* ArcPyMapMgr_getGameObjectNearestCoords( ArcPyMapMgr *self, PyOb
 	float z;
 	uint32 id;
 
-	if( !PyArg_ParseTuple( args, "fffk", &x, &y, &z, &id ) ) 
+    if( !PyArg_ParseTuple( args, "fffI", &x, &y, &z, &id ) )
 	{
 		PyErr_SetString( PyExc_ValueError, "This method requires x,y,z and entry parameters" );
 		return NULL;

--- a/src/plugins/PythonEngine/python/modules/ArcPyObject.cpp
+++ b/src/plugins/PythonEngine/python/modules/ArcPyObject.cpp
@@ -371,7 +371,7 @@ static PyObject* ArcPyObject_setFloatValue( ArcPyObject *self, PyObject *args )
 	uint32 index;
 	float value;
 
-	if( !PyArg_ParseTuple( args, "kf", &index, &value ) )
+    if( !PyArg_ParseTuple( args, "If", &index, &value ) )
 	{
 		PyErr_SetString( PyExc_ValueError, "This method requires an index, and a value parameter" );
 		return NULL;
@@ -400,7 +400,7 @@ static PyObject* ArcPyObject_getFloatValue( ArcPyObject *self, PyObject *args )
 {
 	uint32 index;
 
-	if( !PyArg_ParseTuple( args, "k", &index ) )
+    if( !PyArg_ParseTuple( args, "I", &index ) )
 	{
 		PyErr_SetString( PyExc_ValueError, "This method requires an index parameter" );
 		return NULL;
@@ -428,7 +428,7 @@ static PyObject* ArcPyObject_setUInt32Value( ArcPyObject *self, PyObject *args )
 	uint32 index;
 	uint32 value;
 
-	if( !PyArg_ParseTuple( args, "kk", &index, &value ) )
+    if( !PyArg_ParseTuple( args, "II", &index, &value ) )
 	{
 		PyErr_SetString( PyExc_ValueError, "This method requires an index, and a value parameter" );
 		return NULL;
@@ -458,7 +458,7 @@ static PyObject* ArcPyObject_getUInt32Value( ArcPyObject *self, PyObject *args )
 {
 	uint32 index;
 
-	if( !PyArg_ParseTuple( args, "k", &index ) )
+    if( !PyArg_ParseTuple( args, "I", &index ) )
 	{
 		PyErr_SetString( PyExc_ValueError, "This method requires an index parameter" );
 		return NULL;
@@ -486,7 +486,7 @@ static PyObject* ArcPyObject_setUInt64Value( ArcPyObject *self, PyObject *args )
 	uint32 index;
 	uint64 value;
 
-	if( !PyArg_ParseTuple( args, "kK", &index, &value ) )
+    if( !PyArg_ParseTuple( args, "IK", &index, &value ) )
 	{
 		PyErr_SetString( PyExc_ValueError, "This method requires an index, and a value parameter" );
 		return NULL;
@@ -515,7 +515,7 @@ static PyObject* ArcPyObject_getUInt64Value( ArcPyObject *self, PyObject *args )
 {
 	uint32 index;
 
-	if( !PyArg_ParseTuple( args, "k", &index ) )
+    if( !PyArg_ParseTuple( args, "I", &index ) )
 	{
 		PyErr_SetString( PyExc_ValueError, "This method requires an index, and a value parameter" );
 		return NULL;
@@ -575,7 +575,7 @@ static PyObject* ArcPyObject_setByteFlags( ArcPyObject *self, PyObject *args )
 	uint8 byte;
 	uint8 flags;
 
-	if( !PyArg_ParseTuple( args, "kbb", &index, &byte, &flags ) )
+    if( !PyArg_ParseTuple( args, "Ibb", &index, &byte, &flags ) )
 	{
 		PyErr_SetString( PyExc_ValueError, "This method requires index, byte, flags parameters" );
 		return NULL;
@@ -605,7 +605,7 @@ static PyObject* ArcPyObject_setPhase( ArcPyObject *self, PyObject *args )
 {
 	uint32 phase;
 
-	if( !PyArg_ParseTuple( args, "k", &phase ) )
+    if( !PyArg_ParseTuple( args, "I", &phase ) )
 	{
 		PyErr_SetString( PyExc_ValueError, "This method requires a phase parameter" );
 		return NULL;
@@ -634,7 +634,7 @@ static PyObject* ArcPyObject_addPhase( ArcPyObject *self, PyObject *args )
 {
 	uint32 phase;
 
-	if( !PyArg_ParseTuple( args, "k", &phase ) )
+    if( !PyArg_ParseTuple( args, "I", &phase ) )
 	{
 		PyErr_SetString( PyExc_ValueError, "This method requires a phase parameter" );
 		return NULL;
@@ -662,7 +662,7 @@ static PyObject* ArcPyObject_removePhase( ArcPyObject *self, PyObject *args )
 {
 	uint32 phase;
 
-	if( !PyArg_ParseTuple( args, "k", &phase ) )
+    if( !PyArg_ParseTuple( args, "I", &phase ) )
 	{
 		PyErr_SetString( PyExc_ValueError, "This method requires a phase parameter" );
 		return NULL;
@@ -711,7 +711,7 @@ static PyObject* ArcPyObject_sendZoneWeather( ArcPyObject *self, PyObject *args 
 	uint32 type = 0;
 	float density = 0.0f;
 
-	if( !PyArg_ParseTuple( args, "k|f", &type, &density ) )
+    if( !PyArg_ParseTuple( args, "I|f", &type, &density ) )
 	{
 		PyErr_SetString( PyExc_ValueError, "This method requires a type parameter" );
 		return NULL;
@@ -756,7 +756,7 @@ static PyObject* ArcPyObject_setZoneWeather( ArcPyObject *self, PyObject *args )
 	uint32 type = 0;
 	float density = 0.0f;
 
-	if( !PyArg_ParseTuple( args, "k|f", &type, &density ) )
+    if( !PyArg_ParseTuple( args, "I|f", &type, &density ) )
 	{
 		PyErr_SetString( PyExc_ValueError, "This method requires a type parameter" );
 		return NULL;

--- a/src/plugins/PythonEngine/python/modules/ArcPyPlayer.cpp
+++ b/src/plugins/PythonEngine/python/modules/ArcPyPlayer.cpp
@@ -84,11 +84,11 @@ static PyObject* ArcPyPlayer_getName( ArcPyPlayer *self, PyObject *args )
 ///
 static PyObject* ArcPyPlayer_sendChatMessage( ArcPyPlayer *self, PyObject *args )
 {
-	unsigned long type = 0;
-	unsigned long lang = 0;
+    uint32 type = 0;
+    uint32 lang = 0;
 	const char *msg = NULL;
 
-	if( ! PyArg_ParseTuple( args, "kks", &type, &lang, &msg ) )
+    if( ! PyArg_ParseTuple( args, "IIs", &type, &lang, &msg ) )
 	{
 		return NULL;
 	}
@@ -132,10 +132,10 @@ static PyObject* ArcPyPlayer_toUnit( ArcPyPlayer *self, PyObject *args )
 ///
 static PyObject* ArcPyPlayer_spawnAndEnterVehicle( ArcPyPlayer *self, PyObject *args )
 {
-	unsigned long creatureId;
-	unsigned long delay;
+    uint32 creatureId;
+    uint32 delay;
 
-	if( ! PyArg_ParseTuple( args, "kk", &creatureId, &delay ) )
+    if( ! PyArg_ParseTuple( args, "II", &creatureId, &delay ) )
 	{
 		PyErr_SetString( PyExc_ValueError, "The command requires a creatureId, and a delay." );
 		return NULL;
@@ -205,7 +205,7 @@ static PyObject* ArcPyPlayer_teleport( ArcPyPlayer *self, PyObject *args )
 	float z;
 	float orientation = 0.0f;
 
-	if( ! PyArg_ParseTuple( args, "kfff|f", &map, &x, &y, &z, &orientation ) )
+    if( ! PyArg_ParseTuple( args, "Ifff|f", &map, &x, &y, &z, &orientation ) )
 	{
 		PyErr_SetString( PyExc_ValueError, "The command requires a map Id, and x,y,x coordinates." );
 		return NULL;
@@ -244,7 +244,7 @@ static PyObject* ArcPyPlayer_sendGossipPOI( ArcPyPlayer *self, PyObject *args )
 	uint32 data = 0;
 	const char *name = NULL;
 
-	if( !PyArg_ParseTuple( args, "ffkkks", &x, &y, &icon, &flags, &data, &name ) )
+    if( !PyArg_ParseTuple( args, "ffIIIs", &x, &y, &icon, &flags, &data, &name ) )
 	{
 		return NULL;
 	}
@@ -276,7 +276,7 @@ static PyObject* ArcPyPlayer_markQuestObjectiveAsComplete( ArcPyPlayer *self, Py
 	uint32 objective;
 	uint64 guid = 0;
 
-	if( !PyArg_ParseTuple( args, "kk|K", &quest, &objective, &guid ) )
+    if( !PyArg_ParseTuple( args, "II|K", &quest, &objective, &guid ) )
 	{
 		PyErr_SetString( PyExc_ValueError, "This function requires a quest, and an objective to be specified" );
 		return NULL;
@@ -312,7 +312,7 @@ static PyObject* ArcPyPlayer_addQuestKill( ArcPyPlayer *self, PyObject *args )
 	uint32 objective;
 	uint64 guid = 0;
 
-	if( !PyArg_ParseTuple( args, "kk|K", &quest, &objective, &guid ) )
+    if( !PyArg_ParseTuple( args, "II|K", &quest, &objective, &guid ) )
 	{
 		PyErr_SetString( PyExc_ValueError, "This function requires a quest, and an objective to be specified" );
 		return NULL;
@@ -340,7 +340,7 @@ static PyObject* ArcPyPlayer_sendMovie( ArcPyPlayer *self, PyObject *args )
 {
 	uint32 movieId;
 
-	if( !PyArg_ParseTuple( args, "k", &movieId ) )
+    if( !PyArg_ParseTuple( args, "I", &movieId ) )
 	{
 		PyErr_SetString( PyExc_ValueError, "This function requires a movie id to be specified" );
 		return NULL;
@@ -369,7 +369,7 @@ static PyObject* ArcPyPlayer_sendCinematic( ArcPyPlayer *self, PyObject *args )
 {
 	uint32 cinematicId;
 
-	if( !PyArg_ParseTuple( args, "k", &cinematicId ) )
+    if( !PyArg_ParseTuple( args, "I", &cinematicId ) )
 	{
 		PyErr_SetString( PyExc_ValueError, "This function requires a cinematic id to be specified" );
 		return NULL;
@@ -400,7 +400,7 @@ static PyObject* ArcPyPlayer_addItem( ArcPyPlayer *self, PyObject *args )
 	uint32 itemId;
 	uint32 amount;
 
-	if( !PyArg_ParseTuple( args, "kk", &itemId, &amount ) )
+    if( !PyArg_ParseTuple( args, "II", &itemId, &amount ) )
 	{
 		PyErr_SetString( PyExc_ValueError, "This function requires an item id and amount to be specified" );
 		return NULL;
@@ -431,7 +431,7 @@ static PyObject* ArcPyPlayer_removeItem( ArcPyPlayer *self, PyObject *args )
 	uint32 itemId;
 	uint32 amount;
 
-	if( !PyArg_ParseTuple( args, "kk", &itemId, &amount ) )
+    if( !PyArg_ParseTuple( args, "II", &itemId, &amount ) )
 	{
 		PyErr_SetString( PyExc_ValueError, "This function requires an item id and amount to be specified" );
 		return NULL;
@@ -461,7 +461,7 @@ static PyObject* ArcPyPlayer_hasItem( ArcPyPlayer *self, PyObject *args )
 	uint32 itemId;
 	uint32 amount;
 
-	if( !PyArg_ParseTuple( args, "kk", &itemId, &amount ) )
+    if( !PyArg_ParseTuple( args, "II", &itemId, &amount ) )
 	{
 		PyErr_SetString( PyExc_ValueError, "This function requires an item id and amount to be specified" );
 		return NULL;
@@ -515,7 +515,7 @@ static PyObject* ArcPyPlayer_startTaxi( ArcPyPlayer *self, PyObject *args )
 	uint32 displayId;
 	uint32 startNode;
 
-	if( !PyArg_ParseTuple( args, "kkk", &taxiPathId, &displayId, &startNode ) )
+    if( !PyArg_ParseTuple( args, "III", &taxiPathId, &displayId, &startNode ) )
 	{
 		PyErr_SetString( PyExc_ValueError, "This function requires taxiPathId, displayId, startNode to be specified" );
 		return NULL;
@@ -551,7 +551,7 @@ static PyObject* ArcPyPlayer_startTaxi( ArcPyPlayer *self, PyObject *args )
 static PyObject* ArcPyPlayer_hasQuest( ArcPyPlayer *self, PyObject *args )
 {
 	uint32 questId;
-	if( !PyArg_ParseTuple( args, "k", &questId ) )
+    if( !PyArg_ParseTuple( args, "I", &questId ) )
 	{
 		PyErr_SetString( PyExc_ValueError, "This function requires a quest Id be specified" );
 		return NULL;
@@ -705,7 +705,7 @@ static PyObject* ArcPyPlayer_sendWeather( ArcPyPlayer *self, PyObject *args )
 	uint32 type = 0;
 	float density = 0.0f;
 
-	if( !PyArg_ParseTuple( args, "k|f", &type, &density ) )
+    if( !PyArg_ParseTuple( args, "I|f", &type, &density ) )
 	{
 		PyErr_SetString( PyExc_ValueError, "This method requires a type parameter" );
 		return NULL;

--- a/src/plugins/PythonEngine/python/modules/ArcPyUnit.cpp
+++ b/src/plugins/PythonEngine/python/modules/ArcPyUnit.cpp
@@ -90,12 +90,12 @@ static PyObject* ArcPyUnit_getName( ArcPyUnit *self, PyObject *args )
 ///
 static PyObject* ArcPyUnit_sendChatMessage( ArcPyUnit *self, PyObject *args )
 {
-	unsigned long type = 0;
-	unsigned long lang = 0;
+    uint32 type = 0;
+    uint32 lang = 0;
 	const char *msg = NULL;
 	uint32 delay = 0;
 
-	if( ! PyArg_ParseTuple( args, "kks|k", &type, &lang, &msg, &delay ) )
+    if( ! PyArg_ParseTuple( args, "IIs|I", &type, &lang, &msg, &delay ) )
 	{
 		return NULL;
 	}
@@ -122,7 +122,7 @@ static PyObject* ArcPyUnit_RegisterAIUpdateEvent( ArcPyUnit *self, PyObject *arg
 {
 	uint32 interval;
 
-	if( !PyArg_ParseTuple( args, "k", &interval ) )
+    if( !PyArg_ParseTuple( args, "I", &interval ) )
 	{
 		return NULL;
 	}
@@ -156,7 +156,7 @@ static PyObject* ArcPyUnit_ModifyAIUpdateEvent( ArcPyUnit* self, PyObject* args 
 
 	uint32 interval;
 
-	if( !PyArg_ParseTuple( args, "k", &interval ) )
+    if( !PyArg_ParseTuple( args, "I", &interval ) )
 	{
 		return NULL;
 	}
@@ -262,9 +262,9 @@ static PyObject* ArcPyUnit_dismissVehicle( ArcPyUnit *self, PyObject *args )
 ///
 static PyObject* ArcPyUnit_addVehiclePassenger( ArcPyUnit *self, PyObject *args )
 {
-	unsigned long creatureId;
+    uint32 creatureId;
 
-	if( !PyArg_ParseTuple( args, "k", &creatureId ) )
+    if( !PyArg_ParseTuple( args, "I", &creatureId ) )
 	{
 		PyErr_SetString( PyExc_ValueError, "The command requires a creatureId." );
 		return NULL;
@@ -360,7 +360,7 @@ static PyObject* ArcPyUnit_enterVehicle( ArcPyUnit *self, PyObject *args )
 	uint64 guid;
 	uint32 delay;
 
-	if( !PyArg_ParseTuple( args, "Kk", &guid, &delay ) )
+    if( !PyArg_ParseTuple( args, "KI", &guid, &delay ) )
 	{
 		PyErr_SetString( PyExc_TypeError, "This method requires a guid and a delay parameter" );
 		return NULL;
@@ -487,7 +487,7 @@ static PyObject* ArcPyUnit_playSoundToSet( ArcPyUnit *self, PyObject *args )
 {
 	uint32 soundId;
 
-	if( !PyArg_ParseTuple( args, "k", &soundId ) )
+    if( !PyArg_ParseTuple( args, "I", &soundId ) )
 	{
 		PyErr_SetString( PyExc_TypeError, "This method requires a sound Id parameter" );
 		return NULL;
@@ -516,7 +516,7 @@ static PyObject* ArcPyUnit_setFaction( ArcPyUnit *self, PyObject *args )
 {
 	uint32 faction;
 
-	if( !PyArg_ParseTuple( args, "k", &faction ) )
+    if( !PyArg_ParseTuple( args, "I", &faction ) )
 	{
 		PyErr_SetString( PyExc_TypeError, "This method requires a faction Id parameter" );
 		return NULL;
@@ -630,7 +630,7 @@ static PyObject* ArcPyUnit_setMount( ArcPyUnit *self, PyObject *args )
 {
 	uint32 mountId;
 
-	if( !PyArg_ParseTuple( args, "k", &mountId ) )
+    if( !PyArg_ParseTuple( args, "I", &mountId ) )
 	{
 		PyErr_SetString( PyExc_TypeError, "This method requires a mount Id parameter" );
 		return NULL;
@@ -662,7 +662,7 @@ static PyObject* ArcPyUnit_equipWeapons( ArcPyUnit *self, PyObject *args )
 	uint32 offhandWeaponId;
 	uint32 rangedWeaponId;
 
-	if( !PyArg_ParseTuple( args, "k|kk", &meleeWeaponId, &offhandWeaponId, &rangedWeaponId ) )
+    if( !PyArg_ParseTuple( args, "I|II", &meleeWeaponId, &offhandWeaponId, &rangedWeaponId ) )
 	{
 		PyErr_SetString( PyExc_TypeError, "This method requires at least a melee weapon Id parameter" );
 		return NULL;
@@ -693,7 +693,7 @@ static PyObject* ArcPyUnit_setSheatState( ArcPyUnit *self, PyObject *args )
 {
 	uint32 sheatState = 0;
 
-	if( !PyArg_ParseTuple( args, "k", &sheatState ) )
+    if( !PyArg_ParseTuple( args, "I", &sheatState ) )
 	{
 		PyErr_SetString( PyExc_TypeError, "This method requires a sheat state parameter ( 0 or 1 )" );
 		return NULL;
@@ -795,7 +795,7 @@ static PyObject* ArcPyUnit_hasAura( ArcPyUnit *self, PyObject *args )
 {
 	uint32 spellId;
 
-	if( !PyArg_ParseTuple( args, "k", &spellId ) )
+    if( !PyArg_ParseTuple( args, "I", &spellId ) )
 	{
 		PyErr_SetString( PyExc_TypeError, "This method requires a spellId parameter" );
 		return NULL;
@@ -827,7 +827,7 @@ static PyObject* ArcPyUnit_getAuraBySpellId( ArcPyUnit *self, PyObject *args )
 {
 	uint32 spellId;
 
-	if( !PyArg_ParseTuple( args, "k", &spellId ) )
+    if( !PyArg_ParseTuple( args, "I", &spellId ) )
 	{
 		PyErr_SetString( PyExc_TypeError, "This method requires a spellId parameter" );
 		return NULL;
@@ -884,7 +884,7 @@ static PyObject* ArcPyUnit_setStandState( ArcPyUnit *self, PyObject *args )
 {
 	uint32 state;
 
-	if( !PyArg_ParseTuple( args, "k", &state ) )
+    if( !PyArg_ParseTuple( args, "I", &state ) )
 	{
 		PyErr_SetString( PyExc_TypeError, "This method requires a standstate parameter" );
 		return NULL;
@@ -933,7 +933,7 @@ static PyObject* ArcPyUnit_setMaxHealth( ArcPyUnit *self, PyObject *args )
 {
 	uint32 maxHealth;
 
-	if( !PyArg_ParseTuple( args, "k", &maxHealth ) )
+    if( !PyArg_ParseTuple( args, "I", &maxHealth ) )
 	{
 		PyErr_SetString( PyExc_TypeError, "This method requires a maxHealth parameter" );
 		return NULL;
@@ -982,7 +982,7 @@ static PyObject* ArcPyUnit_setHealth( ArcPyUnit *self, PyObject *args )
 {
 	uint32 health;
 
-	if( !PyArg_ParseTuple( args, "k", &health ) )
+    if( !PyArg_ParseTuple( args, "I", &health ) )
 	{
 		PyErr_SetString( PyExc_TypeError, "This method requires a health parameter" );
 		return NULL;
@@ -1182,7 +1182,7 @@ static PyObject* ArcPyUnit_emote( ArcPyUnit *self, PyObject *args )
 	uint32 emote;
 	uint32 time = 0;
 
-	if( !PyArg_ParseTuple( args, "k|k", &emote, &time ) )
+    if( !PyArg_ParseTuple( args, "I|I", &emote, &time ) )
 	{
 		PyErr_SetString( PyExc_TypeError, "This method requires an emote parameter" );
 		return NULL;
@@ -1216,7 +1216,7 @@ static PyObject* ArcPyUnit_setEmoteState( ArcPyUnit *self, PyObject *args )
 	uint32 emote;
 	uint32 delay = 0;
 
-	if( !PyArg_ParseTuple( args, "k|k", &emote, &delay ) )
+    if( !PyArg_ParseTuple( args, "I|I", &emote, &delay ) )
 	{
 		PyErr_SetString( PyExc_TypeError, "This method requires an emote parameter" );
 		return NULL;
@@ -1341,7 +1341,7 @@ static PyObject* ArcPyUnit_castSpell( ArcPyUnit *self, PyObject *args )
 	int triggeredInt = 0;
 	PyObject *target = NULL;
 
-	if( !PyArg_ParseTuple( args, "k|pO", &spellId, &triggeredInt, &target ) )
+    if( !PyArg_ParseTuple( args, "I|pO", &spellId, &triggeredInt, &target ) )
 	{
 		PyErr_SetString( PyExc_TypeError, "This method requires a spellId" );
 		return NULL;
@@ -1410,7 +1410,7 @@ static PyObject* ArcPyUnit_setDisplayId( ArcPyUnit *self, PyObject *args )
 {
 	uint32 displayId;
 
-	if( !PyArg_ParseTuple( args, "k", &displayId ) )
+    if( !PyArg_ParseTuple( args, "I", &displayId ) )
 	{
 		PyErr_SetString( PyExc_ValueError, "This method requires a display Id" );
 		return NULL;
@@ -1456,7 +1456,7 @@ static PyObject* ArcPyUnit_setNativeDisplayId( ArcPyUnit *self, PyObject *args )
 {
 	uint32 displayId;
 
-	if( !PyArg_ParseTuple( args, "k", &displayId ) )
+    if( !PyArg_ParseTuple( args, "I", &displayId ) )
 	{
 		PyErr_SetString( PyExc_ValueError, "This method requires a display Id" );
 		return NULL;
@@ -1702,7 +1702,7 @@ static PyObject* ArcPyUnit_setChannelSpellId( ArcPyUnit *self, PyObject *args )
 {
 	uint32 spellId;
 
-	if( !PyArg_ParseTuple( args, "k", &spellId ) )
+    if( !PyArg_ParseTuple( args, "I", &spellId ) )
 	{
 		PyErr_SetString( PyExc_ValueError, "This method requires a spellId parameter" );
 		return NULL;

--- a/src/plugins/PythonEngine/python/modules/arcemu_module.cpp
+++ b/src/plugins/PythonEngine/python/modules/arcemu_module.cpp
@@ -57,7 +57,7 @@ extern int registerArcPyWorldSession( PyObject *module );
 ///
 static PyObject* arcemu_RegisterServerHook( PyObject *self, PyObject *args )
 {
-	unsigned long serverEvent = 0;
+    uint32 serverEvent = 0;
 	PyObject *callback = NULL;
 
 	if( !PyArg_ParseTuple( args, "IO", &serverEvent, &callback ) )
@@ -93,8 +93,8 @@ static PyObject* arcemu_RegisterServerHook( PyObject *self, PyObject *args )
 ///
 static PyObject* arcemu_RegisterUnitGossipEvent( PyObject *self, PyObject *args )
 {
-	unsigned long creatureId = 0;
-	unsigned long gossipEvent = 0;
+    uint32 creatureId = 0;
+    uint32 gossipEvent = 0;
 	PyObject *callback = NULL;
 
 	if( !PyArg_ParseTuple( args, "IIO", &creatureId, &gossipEvent, &callback ) )
@@ -128,8 +128,8 @@ static PyObject* arcemu_RegisterUnitGossipEvent( PyObject *self, PyObject *args 
 ///
 static PyObject* arcemu_RegisterItemGossipEvent( PyObject *self, PyObject *args )
 {
-	unsigned long itemId = 0;
-	unsigned long gossipEvent = 0;
+    uint32 itemId = 0;
+    uint32 gossipEvent = 0;
 	PyObject *callback = NULL;
 
 	if( !PyArg_ParseTuple( args, "IIO", &itemId, &gossipEvent, &callback ) )
@@ -162,8 +162,8 @@ static PyObject* arcemu_RegisterItemGossipEvent( PyObject *self, PyObject *args 
 ///
 static PyObject* arcemu_RegisterGOGossipEvent( PyObject *self, PyObject *args )
 {
-	unsigned long goId = 0;
-	unsigned long gossipEvent = 0;
+    uint32 goId = 0;
+    uint32 gossipEvent = 0;
 	PyObject *callback = NULL;
 
 	if( !PyArg_ParseTuple( args, "IIO", &goId, &gossipEvent, &callback ) )
@@ -197,8 +197,8 @@ static PyObject* arcemu_RegisterGOGossipEvent( PyObject *self, PyObject *args )
 ///
 static PyObject* arcemu_RegisterGameObjectEvent( PyObject *self, PyObject *args )
 {
-	unsigned long goId = 0;
-	unsigned long goEvent = 0;
+    uint32 goId = 0;
+    uint32 goEvent = 0;
 	PyObject *callback = NULL;
 
 	if( !PyArg_ParseTuple( args, "IIO", &goId, &goEvent, &callback ) )
@@ -232,8 +232,8 @@ static PyObject* arcemu_RegisterGameObjectEvent( PyObject *self, PyObject *args 
 ///
 static PyObject* arcemu_RegisterUnitEvent( PyObject *self, PyObject *args )
 {
-	unsigned long creatureId = 0;
-	unsigned long creatureEvent = 0;
+    uint32 creatureId = 0;
+    uint32 creatureEvent = 0;
 	PyObject *callback = NULL;
 
 	if( !PyArg_ParseTuple( args, "IIO", &creatureId, &creatureEvent, &callback ) )
@@ -266,8 +266,8 @@ static PyObject* arcemu_RegisterUnitEvent( PyObject *self, PyObject *args )
 ///
 static PyObject* arcemu_RegisterQuestEvent( PyObject *self, PyObject *args )
 {
-	unsigned long questId = 0;
-	unsigned long questEvent = 0;
+    uint32 questId = 0;
+    uint32 questEvent = 0;
 	PyObject *callback = NULL;
 
 
@@ -301,8 +301,8 @@ static PyObject* arcemu_RegisterQuestEvent( PyObject *self, PyObject *args )
 ///
 static PyObject* arcemu_RegisterInstanceEvent( PyObject *self, PyObject *args )
 {
-	unsigned long mapId = 0;
-	unsigned long instanceEvent = 0;
+    uint32 mapId = 0;
+    uint32 instanceEvent = 0;
 	PyObject *callback = NULL;
 
 
@@ -336,7 +336,7 @@ static PyObject* arcemu_RegisterInstanceEvent( PyObject *self, PyObject *args )
 ///
 static PyObject* arcemu_RegisterDummySpellHandler( PyObject *self, PyObject *args )
 {
-	unsigned long spellId;
+    uint32 spellId;
 	PyObject *callback;
 
 	if( !PyArg_ParseTuple( args, "IO", &spellId, &callback ) )
@@ -370,7 +370,7 @@ static PyObject* arcemu_RegisterDummySpellHandler( PyObject *self, PyObject *arg
 ///
 static PyObject* arcemu_RegisterScriptedEffectHandler( PyObject *self, PyObject *args )
 {
-	unsigned long spellId;
+    uint32 spellId;
 	PyObject *callback;
 
 	if( !PyArg_ParseTuple( args, "IO", &spellId, &callback ) )
@@ -403,10 +403,10 @@ static PyObject* arcemu_RegisterScriptedEffectHandler( PyObject *self, PyObject 
 ///
 static PyObject* arcemu_RegisterDummyAuraHandler( PyObject *self, PyObject *args )
 {
-	unsigned long spellId;
+    uint32 spellId;
 	PyObject *callback;
 
-	if( !PyArg_ParseTuple( args, "kO", &spellId, &callback ) )
+    if( !PyArg_ParseTuple( args, "IO", &spellId, &callback ) )
 	{
 		PyErr_SetString( PyExc_ValueError, "This function requires a spell Id and a callback function be specified" );
 		return NULL;


### PR DESCRIPTION
With an ILP64 data model (64bit Linux GCC), the variable type long is 64 bit not 32 bit.
Because of this,  reading into a uint32 type with PyArg_ParseTuple using the format specifier "k" (unsigned long) triggers a stack smashing error as it is an out of bound read.
This patch fixes that.
